### PR TITLE
좀서 패치 내용

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/fast_zs.cfg
+++ b/addons/sourcemod/configs/zombie_riot/fast_zs.cfg
@@ -284,7 +284,7 @@
 		"2.0"
 		{
 			"cash"	"0"
-			"count"	 "3"
+			"count"	 "1"
 			"health"	"15000"
 			"is_boss"	"1"
 			"plugin"	"npc_random_zombie"
@@ -362,7 +362,7 @@
 		"setup"	"30"
 		"spawn_grigori"	"1"
 		"grigori_sells_items_max"	"3"
-		"1.0"
+		"10.0"
 		{
 			"count"		"0"
 			"health"	"45000"
@@ -800,7 +800,7 @@
 		}
 		
 		"map_setup_fake"	"1"
-		"1.0"
+		"10.0"
 		{
 			"count"			"0"
 			"health"		"180000"
@@ -1428,8 +1428,10 @@
 		}
 		"1.0"
 		{
-			"count"		"6"
-			"plugin"	"npc_zs_manhattan_parrot"
+			"count"		"0"
+			"is_boss"	"1"
+			"is_outlined"	"1"
+			"plugin"	"npc_zs_soldier_messenger"
 		}
 		"1.0"
 		{
@@ -1496,13 +1498,6 @@
 			"health"	"800000"
 			"is_boss"	"1"
 			"plugin"	"npc_zs_malfunctioning_heavy"
-		}
-		"1.0"
-		{
-			"count"		"0"
-			"is_boss"	"1"
-			"is_outlined"	"1"
-			"plugin"	"npc_zs_soldier_messenger"
 		}
 		"1.0"
 		{
@@ -1780,7 +1775,7 @@
 		}
 		"1.0"
 		{
-			"count"		"2"
+			"count"		"5"
 			"health"	"50000"
 			"plugin"	"npc_zs_huntsman"
 		}
@@ -1796,12 +1791,12 @@
 		}
 		"1.0"
 		{
-			"count"		"3"
+			"count"		"5"
 			"plugin"	"npc_zs_zombie_soldier"
 		}
 		"1.0"
 		{
-			"count"		"3"
+			"count"		"5"
 			"health"	"50000"
 			"plugin"	"npc_zs_zombie_scout"
 		}
@@ -1829,7 +1824,7 @@
 			"count"		"2"
 			"health"	"250000"	
 			"is_boss"	"1"
-			"plugin"	"npc_zombie_soldier_giant_grave"
+			"plugin"	"npc_zs_soldier_giant_grave"
 		}
 		"1.0"
 		{
@@ -1844,7 +1839,7 @@
 		}
 		"1.0"
 		{
-			"count"		"2"
+			"count"		"5"
 			"health"	"50000"	
 			"plugin"	"npc_infected_tomislav_main"
 		}
@@ -1861,7 +1856,7 @@
 		}
 		"10.0"
 		{
-			"count"		"1"
+			"count"		"3"
 			"health"	"250000"	
 			"is_boss"	"1"
 			"plugin"	"npc_random_zombie"

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_bloated_zombie.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_bloated_zombie.sp
@@ -263,6 +263,7 @@ public void BloatedZombie_NPCDeath(int entity)
 	}
 	float vecMe[3]; WorldSpaceCenter(npc.index, vecMe);
 	Explode_Logic_Custom(40.0, npc.index, npc.index, -1, vecMe, 200.0, 1.0, _, true, 15, _, _, BloatedZombie_ExplodePost);
+	//TE_Particle("asplode_hoodoo", vecMe, NULL_VECTOR, NULL_VECTOR, _, _, _, _, _, _, _, _, _, _, 0.0);
 }
 
 static void BloatedZombie_ExplodePost(int attacker, int victim, float damage, int weapon)

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_gore_blaster.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_gore_blaster.sp
@@ -273,7 +273,7 @@ public void GoreBlaster_NPCDeath(int entity)
 
 	float vecMe[3]; WorldSpaceCenter(npc.index, vecMe);
 	//TE_Particle("asplode_hoodoo", vecMe, NULL_VECTOR, NULL_VECTOR, _, _, _, _, _, _, _, _, _, _, 0.0);
-	// int team = GetTeam(npc.index);
+	//int team = GetTeam(npc.index);
 
 	Explode_Logic_Custom(40.0, npc.index, npc.index, -1, vecMe, 200.0, 1.0, _, true, 15, _, _, GoreBlaster_ExplodePost);
 }

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_vile_bloated_zombie.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_vile_bloated_zombie.sp
@@ -265,6 +265,7 @@ public void VileBloatedZombie_NPCDeath(int entity)
 	}
 	float vecMe[3]; WorldSpaceCenter(npc.index, vecMe);
 	Explode_Logic_Custom(40.0, npc.index, npc.index, -1, vecMe, 200.0, 1.0, _, true, 15, _, _, VileBloatedZombie_ExplodePost);
+	//TE_Particle("asplode_hoodoo", vecMe, NULL_VECTOR, NULL_VECTOR, _, _, _, _, _, _, _, _, _, _, 0.0);
 }
 
 static void VileBloatedZombie_ExplodePost(int attacker, int victim, float damage, int weapon)

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_engineer.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_engineer.sp
@@ -279,7 +279,7 @@ public void InfectedEngineer_ClotThink(int iNPC)
 							if(target > 0) 
 							{
 								if(!ShouldNpcDealBonusDamage(target))
-									SDKHooks_TakeDamage(target, npc.index, npc.index, 10000.0, DMG_CLUB, -1, _, vecHit);
+									SDKHooks_TakeDamage(target, npc.index, npc.index, 500.0, DMG_CLUB, -1, _, vecHit);
 								else
 									SDKHooks_TakeDamage(target, npc.index, npc.index, 10000.0, DMG_CLUB, -1, _, vecHit);
 								// Hit sound

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_manhattan_parrot.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_manhattan_parrot.sp
@@ -361,7 +361,7 @@ public void ManhattanParrot_NPCDeath(int entity)
 	TE_Particle("asplode_hoodoo", vecMe, NULL_VECTOR, NULL_VECTOR, _, _, _, _, _, _, _, _, _, _, 0.0);
 
 	b_NpcIsTeamkiller[npc.index] = true;
-	Explode_Logic_Custom(200.0, npc.index, npc.index, -1, vecMe, 200.0, 1.0, _, true, 40, _, _, _);
+	Explode_Logic_Custom(1000.0, npc.index, npc.index, -1, vecMe, 200.0, 1.0, _, true, 40, _, _, _);
 	b_NpcIsTeamkiller[npc.index] = false;
 
 	

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_soldier_messenger.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_soldier_messenger.sp
@@ -402,7 +402,7 @@ public Action InfectedMessenger_OnTakeDamage(int victim, int &attacker, int &inf
 			Spawn_Reinforcements(npc);
 			npc.PlaySummonSound();
 		}
-		CPrintToChatAll("{green}감염된 전령병{default}: 젠장 기습이다! 지금 당장 여기에 지원이 필요하다!");
+		CPrintToChatAll("{green}감염된 전령병{default}: 젠장! 이곳에 포격 지원이 필요하다 지금 당장!!");
 	}
 	if(RoundToCeil(damage) >= GetEntProp(npc.index, Prop_Data, "m_iHealth"))
 	{
@@ -432,7 +432,7 @@ static void Spawn_Reinforcements(InfectedMessenger npc)
 	heck= maxhealth;
 	maxhealth= heck;
 
-	spawn_index = NPC_CreateByName("npc_zs_cleaner", npc.index, pos, ang, GetTeam(npc.index));
+	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
 	NpcAddedToZombiesLeftCurrently(spawn_index, true);
 	if(spawn_index > MaxClients)
 	{
@@ -440,7 +440,7 @@ static void Spawn_Reinforcements(InfectedMessenger npc)
 		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
 		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
 	}
-	spawn_index = NPC_CreateByName("npc_zs_mlsm", npc.index, pos, ang, GetTeam(npc.index));
+	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
 	NpcAddedToZombiesLeftCurrently(spawn_index, true);
 	if(spawn_index > MaxClients)
 	{
@@ -448,7 +448,47 @@ static void Spawn_Reinforcements(InfectedMessenger npc)
 		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
 		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
 	}
-	spawn_index = NPC_CreateByName("npc_zs_ihbc", npc.index, pos, ang, GetTeam(npc.index));
+	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
+	NpcAddedToZombiesLeftCurrently(spawn_index, true);
+	if(spawn_index > MaxClients)
+	{
+		NpcStats_CopyStats(npc.index, spawn_index);
+		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
+		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
+	}
+	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
+	NpcAddedToZombiesLeftCurrently(spawn_index, true);
+	if(spawn_index > MaxClients)
+	{
+		NpcStats_CopyStats(npc.index, spawn_index);
+		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
+		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
+	}
+	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
+	NpcAddedToZombiesLeftCurrently(spawn_index, true);
+	if(spawn_index > MaxClients)
+	{
+		NpcStats_CopyStats(npc.index, spawn_index);
+		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
+		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
+	}
+	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
+	NpcAddedToZombiesLeftCurrently(spawn_index, true);
+	if(spawn_index > MaxClients)
+	{
+		NpcStats_CopyStats(npc.index, spawn_index);
+		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
+		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
+	}
+	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
+	NpcAddedToZombiesLeftCurrently(spawn_index, true);
+	if(spawn_index > MaxClients)
+	{
+		NpcStats_CopyStats(npc.index, spawn_index);
+		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
+		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
+	}
+	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
 	NpcAddedToZombiesLeftCurrently(spawn_index, true);
 	if(spawn_index > MaxClients)
 	{

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/bosses/npc_doctor_unclean_one.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/bosses/npc_doctor_unclean_one.sp
@@ -233,7 +233,7 @@ methodmap DasNaggenvatcher < CClotBody
 		g_dasnaggenvatcher_die=0.0;
 		WaveStart_SubWaveStart(GetGameTime() + 1000.0);
 		
-		RaidModeTime = GetGameTime(npc.index) + 400.0;
+		RaidModeTime = GetGameTime(npc.index) + 60.0;
 		RaidBossActive = EntIndexToEntRef(npc.index);
 		RaidAllowsBuildings = true;
 		npc.Anger = false;
@@ -808,7 +808,7 @@ public Action DasNaggenvatcher_OnTakeDamage(int victim, int &attacker, int &infl
 			if(EntRefToEntIndex(RaidBossActive)==npc.index)
 				RaidBossActive = INVALID_ENT_REFERENCE;
 			g_dasnaggenvatcher_die = GetGameTime(npc.index) + 40.0;
-			RaidModeTime += 60.0;
+			RaidModeTime += 120.0;
 			
 			SetEntProp(npc.index, Prop_Data, "m_iHealth", 1);
 			damage = 0.0;
@@ -827,7 +827,7 @@ public void DasNaggenvatcher_OnTakeDamagePost(int victim, int attacker, int infl
 		npc.g_TimesSummoned = 1;
 		npc.PlaySummonSound();
 		npc.m_flDoingSpecial = GetGameTime(npc.index) + 10.0;
-		RaidModeTime += 15.0;
+		RaidModeTime += 80.0;
 			
 		DasNaggenvatcherSpawnEnemy(npc.index,"npc_zs_zombie_soldier_pickaxe",40000, RoundToCeil(6.0 * MultiGlobalEnemy));
 		DasNaggenvatcherSpawnEnemy(npc.index,"npc_zs_zombie_soldier",30000, RoundToCeil(6.0 * MultiGlobalEnemy));
@@ -846,7 +846,7 @@ public void DasNaggenvatcher_OnTakeDamagePost(int victim, int attacker, int infl
 		npc.g_TimesSummoned = 2;
 		npc.PlaySummonSound();
 		npc.m_flDoingSpecial = GetGameTime(npc.index) + 10.0;
-		RaidModeTime += 15.0;
+		RaidModeTime += 80.0;
 				
 		DasNaggenvatcherSpawnEnemy(npc.index,"npc_zs_eradicator",70000, RoundToCeil(6.0 * MultiGlobalEnemy));
 		DasNaggenvatcherSpawnEnemy(npc.index,"npc_zs_vile_poisonheadcrab_zombie",80000, RoundToCeil(6.0 * MultiGlobalEnemy));
@@ -862,7 +862,7 @@ public void DasNaggenvatcher_OnTakeDamagePost(int victim, int attacker, int infl
 		npc.g_TimesSummoned = 3;
 		npc.PlaySummonSound();
 		npc.m_flDoingSpecial = GetGameTime(npc.index) + 10.0;
-		RaidModeTime += 15.0;
+		RaidModeTime += 80.0;
 			
 		DasNaggenvatcherSpawnEnemy(npc.index,"npc_zs_ihbc",45000, RoundToCeil(5.0 * MultiGlobalEnemy));
 		DasNaggenvatcherSpawnEnemy(npc.index,"npc_zs_firefighter",50000, RoundToCeil(5.0 * MultiGlobalEnemy));
@@ -881,7 +881,7 @@ public void DasNaggenvatcher_OnTakeDamagePost(int victim, int attacker, int infl
 		DasNaggenvatcherSayWords(npc.index);
 		npc.g_TimesSummoned = 4;
 		npc.PlaySummonSound();
-		RaidModeTime += 15.0;
+		RaidModeTime += 120.0;
 		
 		npc.m_flDoingSpecial = GetGameTime(npc.index) + 10.0;
 		DasNaggenvatcherSpawnEnemy(npc.index,"npc_zs_sniper",20000, RoundToCeil(2.0 * MultiGlobalEnemy));
@@ -973,7 +973,7 @@ void DasNaggenvatcherSayWords(int entity)
 		{
 			case 0:
 			{
-				CPrintToChatAll("{crimson}다스 고르통보호기 메딕{default}: 함께라면 어떤 적이든 처단할 수 있다!");
+				CPrintToChatAll("{crimson}다스 고르통보호기 메딕{default}: 우리가 이룩한 모든 것을 적이 파괴하려 한다.");
 			}
 			case 1:
 			{

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/bosses/npc_zs_unspeakable.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/bosses/npc_zs_unspeakable.sp
@@ -351,7 +351,7 @@ methodmap ZsUnspeakable < CClotBody
 			}
 			RaidModeTime = GetGameTime(npc.index) + 200.0;
 			RaidBossActive = EntIndexToEntRef(npc.index);
-			RaidAllowsBuildings = false;
+			RaidAllowsBuildings = true;
 			float value;
 			char buffers[3][64];
 			ExplodeString(data, ";", buffers, sizeof(buffers), sizeof(buffers[]));
@@ -804,7 +804,7 @@ public Action ZsUnspeakable_OnTakeDamage(int victim, int &attacker, int &inflict
 				npc.m_bAlliesSummoned = true;
 				Spawn_Zombie(npc);
 			}
-			CPrintToChatAll("{crimson}불결한 존재{default}: 이 불경한 놈들이 감히!");
+			CPrintToChatAll("{crimson}불결한 존재{default}: 들린다... 너희의 육신이 부패하고, 심장이 멎는 그 소리가!");
 			RaidModeScaling *= 1.1;
 		}
 	}
@@ -831,11 +831,11 @@ public Action ZsUnspeakable_OnTakeDamage(int victim, int &attacker, int &inflict
 			{
 				case 1:
 				{
-					CPrintToChatAll("{crimson}불결한 존재{default}: 나는 너희들과 이 지랄하면서 놀 시간이 없다.");
+					CPrintToChatAll("{crimson}불결한 존재{default}: 자, 발악하라");
 				}
 				case 2:
 				{
-					CPrintToChatAll("{crimson}저것이 매우 크게 분노하고 있다.");
+					CPrintToChatAll("{crimson}불결한 존재{default}: 귀찮게하는군.");
 				}
 			}
 		}
@@ -1243,6 +1243,10 @@ void ZsUnspeakableSelfDefense(ZsUnspeakable npc, float gameTime, int target, flo
 						WorldSpaceCenter(target, vecHit);
 									
 						float damageDealt = 10.0 * RaidModeScaling;
+						if(i_IsABuilding[target])
+						{
+							damageDealt = 5000.0;
+						}
 
 						SDKHooks_TakeDamage(target, npc.index, npc.index, damageDealt, DMG_CLUB, -1, _, vecHit);	
 						Elemental_AddPheromoneDamage(target, npc.index, RoundToNearest(damageDealt * 0.15), true, true);							


### PR DESCRIPTION
1. 웨이브

1) 32 웨이브에 나오던 맨해튼 앵무새 삭제

2) 35 웨이브에 나오던 감염된 전령병이 32웨이브로 옮겨짐

3) 10/20 웨이브 보스도 30 웨이브 보스와 동일하게 보스 스폰 이후 10초간 추가 지원이 나오지 않음

2. 좀비 관련

1) 맨해튼 앵무새의 자폭 피해량: 200 -> 1000

2) 감염된 전령병의 체력이 50% 이하로 떨어졌을때 나오는 지원군이 맨해튼 앵무새로 변경됨

3) 다스 고르통보호기 메딕의 초기 광폭화 시간: 400 -> 60
다스 고르통보호기 메딕의 지원군 스폰때 주는 추가 광폭화 시간: 15 -> 80
마지막 공세의 경우 15 -> 120
다스 고르통보호기 메딕의 모든 지원군을 죽였을때 주는 추가 광폭화 시간: 60 -> 120

4) 불결한 존재 보스전때 보스와 좀비들이 건물을 통과할 수 없게 바꿨으며 건물도 공격대상으로 인식함

5) 불결한 존재의 건물 피해량이 5000으로 증가