### PR TITLE
좀서 패치 내용

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/fast_zs.cfg
+++ b/addons/sourcemod/configs/zombie_riot/fast_zs.cfg
@@ -18,7 +18,7 @@
 		"file"		"#zombie_riot/gmod_zs/waveset/setup_10.mp3"
 		"time"		"29.8"
 		"download"	"1"
-		"name"		"I don't fucking know"
+		"name"		"Gmod - Zombie Survival"
 		"author"	"it's from Zombie Survival"
 		"volume"	"0.7"
 	}
@@ -309,7 +309,7 @@
 			"file"		"#zombie_riot/gmod_zs/waveset/setup_10.mp3"
 			"time"		"29.8"
 			"download"	"1"
-			"name"		"I don't fucking know"
+			"name"		"Gmod - Zombie Survival"
 			"author"	"it's from Zombie Survival"
 			"volume"	"0.7"
 		}
@@ -754,7 +754,7 @@
 			"file"		"#zombie_riot/gmod_zs/waveset/setup_20.mp3"
 			"time"		"31.2"
 			"download"	"1"
-			"name"		"I don't fucking know"
+			"name"		"Gmod - Zombie Survival"
 			"author"	"it's from Zombie Survival"
 			"volume"	"0.7"
 		}
@@ -1230,9 +1230,8 @@
 		}
 		"0.0"
 		{
-			"count"		"0"
-			"health"	"7500"	
-			"plugin"	"npc_zs_flesh_creeper"
+			"count"		"2"
+			"plugin"	"npc_zs_hmo"
 		}
 	}
 	"29"
@@ -1243,7 +1242,7 @@
 			"file"		"#zombie_riot/gmod_zs/waveset/setup_30.mp3"
 			"time"		"31.1"
 			"download"	"1"
-			"name"		"I don't fucking know"
+			"name"		"Gmod - Zombie Survival"
 			"author"	"it's from Zombie Survival"
 			"volume"	"0.7"
 		}
@@ -1422,9 +1421,8 @@
 		"cash"	"1850"
 		"5.0"
 		{
-			"count"		"0"
-			"health"	"20000"	
-			"plugin"	"npc_zs_flesh_creeper"
+			"count"		"8"
+			"plugin"	"npc_zs_eradicator"
 		}
 		"1.0"
 		{
@@ -1570,7 +1568,7 @@
 		"1.0"
 		{
 			"count"		"5"
-			"plugin"	"npc_zs_combine_soldier_elite"
+			"plugin"	"npc_zs_sniper"
 		}
 		"0.0"
 		{
@@ -1673,7 +1671,7 @@
 		}
 		"1.0"
 		{
-			"count"		"2"
+			"count"		"5"
 			"health"	"112500"
 			"is_boss"	"1"
 			"plugin"	"npc_random_zombie"
@@ -1684,21 +1682,10 @@
 			"count"		"6"
 			"plugin"	"npc_zs_manhattan_parrot"
 		}
-		"5.0"
-		{
-			"count"		"0"
-			"health"	"20000"	
-			"plugin"	"npc_zs_flesh_creeper"
-		}
-		"1.0"
+		"0.0"
 		{
 			"count"		"10"
 			"plugin"	"npc_zs_sniper"
-		}
-		"0.0"
-		{
-			"count"		"20"
-			"plugin"	"npc_zs_ninja_zombie_spy"
 		}
 	}
 	"39"
@@ -1709,7 +1696,7 @@
 			"file"		"#zombie_riot/gmod_zs/waveset/setup_40.mp3"
 			"time"		"31.1"
 			"download"	"1"
-			"name"		"I don't fucking know"
+			"name"		"Gmod - Zombie Survival"
 			"author"	"it's from Zombie Survival"
 			"volume"	"0.7"
 		}
@@ -1833,7 +1820,7 @@
 		}
 		"1.0"
 		{
-			"count"		"6"
+			"count"		"8"
 			"health"	"10000"	
 			"plugin"	"npc_zs_kamikaze_demo"
 		}
@@ -1856,7 +1843,7 @@
 		}
 		"10.0"
 		{
-			"count"		"3"
+			"count"		"4"
 			"health"	"250000"	
 			"is_boss"	"1"
 			"plugin"	"npc_random_zombie"
@@ -1896,7 +1883,7 @@
 		}
 		"1.0"
 		{
-			"count"		"2"
+			"count"		"5"
 			"plugin"	"npc_zs_zombie_sniper_jarate"
 		}
 		"1.0"
@@ -1927,7 +1914,7 @@
 		}
 		"0.00"
 		{
-			"cash"			"4000"
+			"cash"			"49500"
 			"count"			"0"
 			"health"		"3000000"	
 			"is_boss"		"2"
@@ -1945,7 +1932,7 @@
 		"0.0"
 		{
 			"count"			"0"
-			"health"		"7000000"
+			"health"		"10000000"
 			"is_boss"		"3"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_bloated_zombie.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_bloated_zombie.sp
@@ -221,7 +221,6 @@ public void BloatedZombie_ClotThink(int iNPC)
 									SDKHooks_TakeDamage(target, npc.index, npc.index, 80.0, DMG_CLUB, -1, _, vecHit);
 								else
 									SDKHooks_TakeDamage(target, npc.index, npc.index, 120.0, DMG_CLUB, -1, _, vecHit);
-									Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 10 : 10);
 							}
 							
 							npc.PlayMeleeHitSound();

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_ghoul.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_ghoul.sp
@@ -208,14 +208,17 @@ public void Ghoul_ClotThink(int iNPC)
 						{
 							float damageAmount = ShouldNpcDealBonusDamage(target) ? 100.0 : 80.0;
 							SDKHooks_TakeDamage(target, npc.index, npc.index, damageAmount, DMG_CLUB, -1, _, vecHit);
-							Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 30 : 10);
-							int flagsStun = 0;
-							if(!HasSpecificBuff(target, "Fluid Movement"))
-										flagsStun |= TF_STUNFLAG_SLOWDOWN;
+							if (!i_IsABuilding[target])
+							{
+								Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 30 : 10);
+								int flagsStun = 0;
+								if(!HasSpecificBuff(target, "Fluid Movement"))
+											flagsStun |= TF_STUNFLAG_SLOWDOWN;
 
-							if(target <= MaxClients)
-								TF2_StunPlayer(target, 2.0, 0.5, flagsStun);
-							ApplyStatusEffect(npc.index, target, "Cellular Breakdown", 8.0);
+								if(target <= MaxClients)
+									TF2_StunPlayer(target, 2.0, 0.5, flagsStun);
+								ApplyStatusEffect(npc.index, target, "Cellular Breakdown", 8.0);
+							}
 							npc.PlayMeleeHitSound();
 						}
 						else

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_headcrab.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_headcrab.sp
@@ -102,6 +102,7 @@ methodmap ZSHeadcrab < CSeaBody
 		npc.m_flGetClosestTargetTime = 0.0;
 		npc.m_flNextMeleeAttack = 0.0;
 		npc.m_flAttackHappens = 0.0;
+		npc.m_flMeleeArmor = 3.0;
 		f_ExtraOffsetNpcHudAbove[npc.index] = -65.0;
 
 		return npc;

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_poisonheadcrab.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_poisonheadcrab.sp
@@ -108,6 +108,7 @@ methodmap ZSPoisonHeadcrab < CSeaBody
 		npc.m_flGetClosestTargetTime = 0.0;
 		npc.m_flNextMeleeAttack = 0.0;
 		npc.m_flAttackHappens = 0.0;
+		npc.m_flMeleeArmor = 3.0;
 		f_ExtraOffsetNpcHudAbove[npc.index] = -65.0;
 
 		return npc;
@@ -184,6 +185,11 @@ public void ZSPoisonHeadcrab_ClotThink(int iNPC)
 					{
 						npc.PlayMeleeHitSound();
 						SDKHooks_TakeDamage(target, npc.index, npc.index, 0.0, DMG_CLUB, -1, _, vecHit);
+						if (i_IsABuilding[target])
+						{
+							// 구조물일 때는 여기서 더 이상 아래로 내려가지 않고 종료
+							return; 
+						}
 						if(!HasSpecificBuff(target, "Envenomed"))
 						{
 							ApplyStatusEffect(npc.index, target, "Envenomed", 10.0);
@@ -192,12 +198,11 @@ public void ZSPoisonHeadcrab_ClotThink(int iNPC)
 								Force_ExplainBuffToClient(target, "Envenomed");
 								SetEntProp(target, Prop_Data, "m_iHealth", 1);
 								HealEntityGlobal(target, target, 250.0, 1.0, 20.0, HEAL_SELFHEAL);
+								Custom_Knockback(npc.index, target, 500.0, true);
+								TF2_AddCondition(target, TFCond_LostFooting, 0.5);
+								TF2_AddCondition(target, TFCond_AirCurrent, 0.5);
+								ApplyStatusEffect(npc.index, target, "Unstoppable Force", 0.5);
 							}
-						}
-						if (i_IsABuilding[target])
-						{
-							//use void a subtitute, it just reduces repair HP alot.
-							Elemental_AddVoidDamage(target, npc.index, 2000, false, false);
 						}
 						if(b_ThisWasAnNpc[target])
 						{

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_poisonzombie.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_poisonzombie.sp
@@ -254,15 +254,15 @@ public void ZSPoisonZombie_ClotThink(int iNPC)
 								
 								if(target > 0) 
 								{
+									if(!ShouldNpcDealBonusDamage(target))
 									{
-										if(!ShouldNpcDealBonusDamage(target))
 										SDKHooks_TakeDamage(target, npc.index, npc.index, 160.0, DMG_CLUB, -1, _, vecHit);
-									
-									else
-										SDKHooks_TakeDamage(target, npc.index, npc.index, 240.0, DMG_CLUB, -1, _, vecHit);
 										Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 50 : 10);
 									}
-									
+									else
+									{
+										SDKHooks_TakeDamage(target, npc.index, npc.index, 240.0, DMG_CLUB, -1, _, vecHit);
+									}
 									// Hit particle
 									
 									

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_shadow_walker.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/15/npc_zs_shadow_walker.sp
@@ -222,13 +222,15 @@ public void ShadowWalker_ClotThink(int iNPC)
 						TR_GetEndPosition(vecHit, swingTrace);
 						if(target > 0) 
 						{
-							{
 								if(!ShouldNpcDealBonusDamage(target))
+								{
+									ApplyStatusEffect(npc.index, target, "Cellular Breakdown", 8.0);
 									SDKHooks_TakeDamage(target, npc.index, npc.index, 80.0, DMG_CLUB, -1, _, vecHit);
+								}
 								else
+								{
 									SDKHooks_TakeDamage(target, npc.index, npc.index, 120.0, DMG_CLUB, -1, _, vecHit);
-								ApplyStatusEffect(npc.index, target, "Cellular Breakdown", 8.0);
-							}
+								}
 							
 							npc.PlayMeleeHitSound();
 						}

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_elder_ghoul.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_elder_ghoul.sp
@@ -211,14 +211,17 @@ public void ElderGhoul_ClotThink(int iNPC)
 						{
 							float damageAmount = ShouldNpcDealBonusDamage(target) ? 100.0 : 120.0;
 							SDKHooks_TakeDamage(target, npc.index, npc.index, damageAmount, DMG_CLUB, -1, _, vecHit);
-							Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 45 : 10);
-							int flagsStun = 0;
-							if(!HasSpecificBuff(target, "Fluid Movement"))
-										flagsStun |= TF_STUNFLAG_SLOWDOWN;
+							if (!i_IsABuilding[target])
+							{
+								Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 45 : 10);
+								int flagsStun = 0;
+								if(!HasSpecificBuff(target, "Fluid Movement"))
+											flagsStun |= TF_STUNFLAG_SLOWDOWN;
 
-							if(target <= MaxClients)
-								TF2_StunPlayer(target, 2.0, 0.5, flagsStun);
-							ApplyStatusEffect(npc.index, target, "Cellular Breakdown", 8.0);
+								if(target <= MaxClients)
+									TF2_StunPlayer(target, 2.0, 0.5, flagsStun);
+								ApplyStatusEffect(npc.index, target, "Cellular Breakdown", 8.0);
+							}
 							npc.PlayMeleeHitSound();
 						}
 						else

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_fast_headcrab.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_fast_headcrab.sp
@@ -104,6 +104,7 @@ methodmap FastHeadcrab < CSeaBody
 		npc.m_flGetClosestTargetTime = 0.0;
 		npc.m_flNextMeleeAttack = 0.0;
 		npc.m_flAttackHappens = 0.0;
+		npc.m_flMeleeArmor = 3.0;
 		f_ExtraOffsetNpcHudAbove[npc.index] = -65.0;
 
 		return npc;

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_gore_blaster.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_gore_blaster.sp
@@ -224,14 +224,15 @@ public void GoreBlaster_ClotThink(int iNPC)
 						TR_GetEndPosition(vecHit, swingTrace);
 						if(target > 0) 
 						{
+							if(!ShouldNpcDealBonusDamage(target))
 							{
-								if(!ShouldNpcDealBonusDamage(target))
-									SDKHooks_TakeDamage(target, npc.index, npc.index, 80.0, DMG_CLUB, -1, _, vecHit);
-								else
-									SDKHooks_TakeDamage(target, npc.index, npc.index, 100.0, DMG_CLUB, -1, _, vecHit);					
+								SDKHooks_TakeDamage(target, npc.index, npc.index, 80.0, DMG_CLUB, -1, _, vecHit);
+								StartBleedingTimer(target, npc.index, 10.0, 4, -1, DMG_TRUEDAMAGE, 0);
 							}
-
-							StartBleedingTimer(target, npc.index, 10.0, 4, -1, DMG_TRUEDAMAGE, 0);
+							else
+							{
+								SDKHooks_TakeDamage(target, npc.index, npc.index, 100.0, DMG_CLUB, -1, _, vecHit);
+							}
 							
 							npc.PlayMeleeHitSound();
 						}

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_poisonheadcrab_zombie.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_poisonheadcrab_zombie.sp
@@ -254,13 +254,14 @@ public void ZSPoisonheadcrabZombie_ClotThink(int iNPC)
 								
 								if(target > 0) 
 								{
+									if(!ShouldNpcDealBonusDamage(target))
 									{
-										if(!ShouldNpcDealBonusDamage(target))
-										SDKHooks_TakeDamage(target, npc.index, npc.index, 380.0, DMG_CLUB, -1, _, vecHit);
-									
+									Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 50 : 10);
+									SDKHooks_TakeDamage(target, npc.index, npc.index, 380.0, DMG_CLUB, -1, _, vecHit);
+									}
 									else
+									{
 										SDKHooks_TakeDamage(target, npc.index, npc.index, 720.0, DMG_CLUB, -1, _, vecHit);
-										Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 50 : 10);
 									}
 									
 									// Hit particle

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_vile_bloated_zombie.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/30/npc_zs_vile_bloated_zombie.sp
@@ -218,14 +218,15 @@ public void VileBloatedZombie_ClotThink(int iNPC)
 						TR_GetEndPosition(vecHit, swingTrace);
 						if(target > 0) 
 						{
+							if(!ShouldNpcDealBonusDamage(target))
 							{
-								if(!ShouldNpcDealBonusDamage(target))
-									SDKHooks_TakeDamage(target, npc.index, npc.index, 350.0, DMG_CLUB, -1, _, vecHit);
-								else
-									SDKHooks_TakeDamage(target, npc.index, npc.index, 1000.0, DMG_CLUB, -1, _, vecHit);
-									Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 10 : 10);
+								SDKHooks_TakeDamage(target, npc.index, npc.index, 350.0, DMG_CLUB, -1, _, vecHit);
+								Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 10 : 10);
 							}
-							
+							else
+							{
+								SDKHooks_TakeDamage(target, npc.index, npc.index, 1000.0, DMG_CLUB, -1, _, vecHit);
+							}
 							npc.PlayMeleeHitSound();
 						}
 						else

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_angryheadcrab.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_angryheadcrab.sp
@@ -103,6 +103,7 @@ methodmap Angryheadcrab < CSeaBody
 		npc.m_flGetClosestTargetTime = 0.0;
 		npc.m_flNextMeleeAttack = 0.0;
 		npc.m_flAttackHappens = 0.0;
+		npc.m_flMeleeArmor = 3.0;
 		f_ExtraOffsetNpcHudAbove[npc.index] = -65.0;
 		
 		SetEntityRenderColor(npc.index, 255, 0, 0, 255);

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_engineer.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_engineer.sp
@@ -279,9 +279,14 @@ public void InfectedEngineer_ClotThink(int iNPC)
 							if(target > 0) 
 							{
 								if(!ShouldNpcDealBonusDamage(target))
+								{
 									SDKHooks_TakeDamage(target, npc.index, npc.index, 500.0, DMG_CLUB, -1, _, vecHit);
+									ApplyStatusEffect(npc.index, target, "Cudgelled", 8.0);
+								}
 								else
+								{
 									SDKHooks_TakeDamage(target, npc.index, npc.index, 10000.0, DMG_CLUB, -1, _, vecHit);
+								}
 								// Hit sound
 								npc.PlayMeleeHitSound();
 								

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_sniper_jarate.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_sniper_jarate.sp
@@ -184,20 +184,16 @@ public void InfectedSniperjarate_ClotThink(int iNPC)
 					{
 						npc.PlayMeleeHitSound();
 						SDKHooks_TakeDamage(target, npc.index, npc.index, 200.0, DMG_CLUB);
-						Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 100 : 50);
-						
-						if(!NpcStats_IsEnemySilenced(npc.index))
+						if (!i_IsABuilding[target])
 						{
-							ApplyStatusEffect(npc.index, npc.index, "Silenced", 20.0);
+							Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 100 : 50);
+							int flagsStun = 0;
+							if(!HasSpecificBuff(target, "Fluid Movement"))
+								flagsStun |= TF_STUNFLAG_SLOWDOWN;
 
-							if(target > MaxClients)
-							{
-								ApplyStatusEffect(npc.index, target, "Teslar Mule", 5.0);
-							}
-							else
-							{
-								TF2_AddCondition(target, TFCond_Jarated, 5.0);
-							}
+							if(target <= MaxClients)
+								TF2_StunPlayer(target, 2.0, 0.9, flagsStun);
+							ApplyStatusEffect(npc.index, target, "Cellular Breakdown", 8.0);
 						}
 					}
 				}

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_ihbc.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_ihbc.sp
@@ -251,10 +251,8 @@ public void InfectedHazardous_ClotThink(int iNPC)
 							{
 								
 								if(!ShouldNpcDealBonusDamage(target))
-									SDKHooks_TakeDamage(target, npc.index, npc.index, 175.0, DMG_CLUB, -1, _, vecHit);
-								else
-									SDKHooks_TakeDamage(target, npc.index, npc.index, 500.0, DMG_CLUB, -1, _, vecHit);
-									Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 30 : 10);
+								{
+									Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 100 : 50);
 									int flagsStun = 0;
 									if(!HasSpecificBuff(target, "Fluid Movement"))
 												flagsStun |= TF_STUNFLAG_SLOWDOWN;
@@ -262,6 +260,12 @@ public void InfectedHazardous_ClotThink(int iNPC)
 									if(target <= MaxClients)
 										TF2_StunPlayer(target, 2.0, 0.9, flagsStun);
 									ApplyStatusEffect(npc.index, target, "Cellular Breakdown", 8.0);
+									SDKHooks_TakeDamage(target, npc.index, npc.index, 175.0, DMG_CLUB, -1, _, vecHit);
+								}
+								else
+								{
+									SDKHooks_TakeDamage(target, npc.index, npc.index, 500.0, DMG_CLUB, -1, _, vecHit);
+								}
 								// Hit sound
 								npc.PlayMeleeHitSound();
 								

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_manhattan_parrot.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_manhattan_parrot.sp
@@ -361,7 +361,7 @@ public void ManhattanParrot_NPCDeath(int entity)
 	TE_Particle("asplode_hoodoo", vecMe, NULL_VECTOR, NULL_VECTOR, _, _, _, _, _, _, _, _, _, _, 0.0);
 
 	b_NpcIsTeamkiller[npc.index] = true;
-	Explode_Logic_Custom(1000.0, npc.index, npc.index, -1, vecMe, 200.0, 1.0, _, true, 40, _, _, _);
+	Explode_Logic_Custom(5000.0, npc.index, npc.index, -1, vecMe, 200.0, 1.0, _, true, 40, _, _, _);
 	b_NpcIsTeamkiller[npc.index] = false;
 
 	

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_soldier_messenger.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_soldier_messenger.sp
@@ -98,11 +98,6 @@ methodmap InfectedMessenger < CClotBody
 	{
 		EmitSoundToAll(g_MeleeHitSounds[GetRandomInt(0, sizeof(g_MeleeHitSounds) - 1)], this.index, SNDCHAN_AUTO, NORMAL_ZOMBIE_SOUNDLEVEL, _, NORMAL_ZOMBIE_VOLUME, _);	
 	}
-	property bool m_bAlliesSummoned
-	{
-		public get()							{ return b_InKame[this.index]; }
-		public set(bool TempValueForProperty) 	{ b_InKame[this.index] = TempValueForProperty; }
-	}
 	public void PlaySummonSound() 
 	{
 		EmitSoundToAll(g_SummonSounds[GetRandomInt(0, sizeof(g_SummonSounds) - 1)], this.index, SNDCHAN_AUTO, RAIDBOSS_ZOMBIE_SOUNDLEVEL, _, BOSS_ZOMBIE_VOLUME);
@@ -150,6 +145,7 @@ methodmap InfectedMessenger < CClotBody
 
 		func_NPCDeath[npc.index] = ClotDeath;
 		func_NPCOnTakeDamage[npc.index] = InfectedMessenger_OnTakeDamage;
+		SDKHook(npc.index, SDKHook_OnTakeDamagePost, InfectedMessenger_OnTakeDamagePost);
 		func_NPCThink[npc.index] = ClotThink;
 		npc.i_GunMode = Waves_GetRoundScale();
 		
@@ -160,9 +156,9 @@ methodmap InfectedMessenger < CClotBody
 		npc.m_flRangedArmor = 0.2;
 		int WaveSetting = 1;
 		i_RaidGrantExtra[npc.index] = WaveSetting;
-		npc.m_bAlliesSummoned = false;
 		npc.WhatWaves = 0;
 		npc.InWaves = 0;
+		npc.g_TimesSummoned = 0;
 		g_infected_messenger_died=false;
 		g_infected_messenger_die=0.0;
 		AddNpcToAliveList(npc.index, 1);
@@ -396,13 +392,6 @@ public Action InfectedMessenger_OnTakeDamage(int victim, int &attacker, int &inf
 	if((ReturnEntityMaxHealth(npc.index)/2) >= GetEntProp(npc.index, Prop_Data, "m_iHealth") && !npc.Anger) 
 	{
 		npc.Anger = true;
-		if(!npc.m_bAlliesSummoned)
-		{
-			npc.m_bAlliesSummoned = true;
-			Spawn_Reinforcements(npc);
-			npc.PlaySummonSound();
-		}
-		CPrintToChatAll("{green}감염된 전령병{default}: 젠장! 이곳에 포격 지원이 필요하다 지금 당장!!");
 	}
 	if(RoundToCeil(damage) >= GetEntProp(npc.index, Prop_Data, "m_iHealth"))
 	{
@@ -421,81 +410,6 @@ public Action InfectedMessenger_OnTakeDamage(int victim, int &attacker, int &inf
 		}
 	}
 	return Plugin_Changed;
-}
-static void Spawn_Reinforcements(InfectedMessenger npc)
-{
-	float pos[3]; GetEntPropVector(npc.index, Prop_Data, "m_vecAbsOrigin", pos);
-	float ang[3]; GetEntPropVector(npc.index, Prop_Data, "m_angRotation", ang);
-	int maxhealth = ReturnEntityMaxHealth(npc.index);
-	int heck;
-	int spawn_index;
-	heck= maxhealth;
-	maxhealth= heck;
-
-	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
-	NpcAddedToZombiesLeftCurrently(spawn_index, true);
-	if(spawn_index > MaxClients)
-	{
-		NpcStats_CopyStats(npc.index, spawn_index);
-		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
-		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
-	}
-	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
-	NpcAddedToZombiesLeftCurrently(spawn_index, true);
-	if(spawn_index > MaxClients)
-	{
-		NpcStats_CopyStats(npc.index, spawn_index);
-		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
-		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
-	}
-	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
-	NpcAddedToZombiesLeftCurrently(spawn_index, true);
-	if(spawn_index > MaxClients)
-	{
-		NpcStats_CopyStats(npc.index, spawn_index);
-		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
-		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
-	}
-	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
-	NpcAddedToZombiesLeftCurrently(spawn_index, true);
-	if(spawn_index > MaxClients)
-	{
-		NpcStats_CopyStats(npc.index, spawn_index);
-		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
-		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
-	}
-	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
-	NpcAddedToZombiesLeftCurrently(spawn_index, true);
-	if(spawn_index > MaxClients)
-	{
-		NpcStats_CopyStats(npc.index, spawn_index);
-		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
-		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
-	}
-	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
-	NpcAddedToZombiesLeftCurrently(spawn_index, true);
-	if(spawn_index > MaxClients)
-	{
-		NpcStats_CopyStats(npc.index, spawn_index);
-		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
-		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
-	}
-	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
-	NpcAddedToZombiesLeftCurrently(spawn_index, true);
-	if(spawn_index > MaxClients)
-	{
-		NpcStats_CopyStats(npc.index, spawn_index);
-		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
-		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
-	}
-	spawn_index = NPC_CreateByName("npc_zs_manhattan_parrot", npc.index, pos, ang, GetTeam(npc.index));
-	NpcAddedToZombiesLeftCurrently(spawn_index, true);
-	if(spawn_index > MaxClients)
-	{
-		NpcStats_CopyStats(npc.index, spawn_index);
-		SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
-		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
-	}
 }
 static void Spawn_Chaos(InfectedMessenger npc)
 {
@@ -535,7 +449,104 @@ static void Spawn_Chaos(InfectedMessenger npc)
 		SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);
 	}
 }
+public void InfectedMessenger_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype) 
+{
+	InfectedMessenger npc = view_as<InfectedMessenger>(victim);
+	float maxhealth = float(ReturnEntityMaxHealth(npc.index));
+	float health = float(GetEntProp(npc.index, Prop_Data, "m_iHealth"));
+	float Ratio = health / maxhealth;
+	if(Ratio <= 0.85 && npc.g_TimesSummoned < 1)
+	{
+		npc.g_TimesSummoned = 1;
+		npc.m_flDoingSpecial = GetGameTime(npc.index) + 10.0;
+		npc.PlaySummonSound();
+		CPrintToChatAll("{crimson}감염된 전령병{default}: 젠장 기습이다!!!! 이곳에 지원군을 보내라 지금 당장!!!!");
+		InfectedMessengerSpawnEnemy(npc.index,"npc_zs_cleaner",50000, RoundToCeil(6.0 * MultiGlobalEnemy));
+		InfectedMessengerSpawnEnemy(npc.index,"npc_zs_zombie_soldier",30000, RoundToCeil(2.0 * MultiGlobalEnemy));
+		InfectedMessengerSpawnEnemy(npc.index,"npc_zs_mlsm",50000, RoundToCeil(6.0 * MultiGlobalEnemy));
+		InfectedMessengerSpawnEnemy(npc.index,"npc_infected_tomislav_main",20000, RoundToCeil(4.0 * MultiGlobalEnemy));
+		InfectedMessengerSpawnEnemy(npc.index,"npc_zs_zombie_sniper_jarate",40000, RoundToCeil(2.0 * MultiGlobalEnemy));
+	}
+	else if(Ratio <= 0.20 && npc.g_TimesSummoned < 2)
+	{
+		npc.g_TimesSummoned = 2;
+		npc.m_flDoingSpecial = GetGameTime(npc.index) + 10.0;
+		npc.PlaySummonSound();
+		CPrintToChatAll("{crimson}감염된 전령병{default}: 아직도 놈들이 살아있다!!! 이곳에 당장 공습을 때려!!!!");
+		InfectedMessengerSpawnEnemy(npc.index,"npc_zs_manhattan_parrot",30000, RoundToCeil(6.0 * MultiGlobalEnemy));
+		InfectedMessengerSpawnEnemy(npc.index,"npc_zs_kamikaze_demo",6000, RoundToCeil(8.0 * MultiGlobalEnemy));
+	}
+}
+void InfectedMessengerSpawnEnemy(int infectedmessenger, char[] plugin_name, int health = 0, int count, bool is_a_boss = false)
+{
+	if(GetTeam(infectedmessenger) == TFTeam_Red)
+	{
+		count /= 2;
+		if(count < 1)
+		{
+			count = 1;
+		}
+		for(int Spawns; Spawns <= count; Spawns++)
+		{
+			float pos[3]; GetEntPropVector(infectedmessenger, Prop_Data, "m_vecAbsOrigin", pos);
+			float ang[3]; GetEntPropVector(infectedmessenger, Prop_Data, "m_angRotation", ang);
+			
+			int summon = NPC_CreateByName(plugin_name, -1, pos, ang, GetTeam(infectedmessenger));
+			if(summon > MaxClients)
+			{
+				fl_Extra_Damage[summon] = 10.0;
+				if(!health)
+				{
+					health = GetEntProp(summon, Prop_Data, "m_iMaxHealth");
+				}
+				SetEntProp(summon, Prop_Data, "m_iHealth", health / 10);
+				SetEntProp(summon, Prop_Data, "m_iMaxHealth", health / 10);
+			}
+		}
+		return;
+	}
+		
+	Enemy enemy;
+	enemy.Index = NPC_GetByPlugin(plugin_name);
+	if(health != 0)
+	{
+		enemy.Health = health;
+	}
+	enemy.Is_Boss = view_as<int>(is_a_boss);
+	enemy.Is_Immune_To_Nuke = true;
+	//do not bother outlining.
+	enemy.ExtraMeleeRes = 1.0;
+	enemy.ExtraRangedRes = 1.0;
+	enemy.ExtraSpeed = 1.0;
+	enemy.ExtraDamage = 1.0;
+	enemy.ExtraSize = 1.0;		
+	enemy.Team = GetTeam(infectedmessenger);
+	
+	if(!Waves_InFreeplay())
+	{
+		for(int i; i<count; i++)
+		{
+			Waves_AddNextEnemy(enemy);
+		}
+	}
+	else
+	{
+		int postWaves = CurrentRound[Rounds_Default] - Waves_GetMaxRound();
+		char npc_classname[60];
+		NPC_GetPluginById(i_NpcInternalId[enemy.Index], npc_classname, sizeof(npc_classname));
 
+		Freeplay_AddEnemy(postWaves, enemy, count, true);
+		if(count > 0)
+		{
+			for(int a; a < count; a++)
+			{
+				Waves_AddNextEnemy(enemy);
+			}
+		}
+	}
+
+	Zombies_Currently_Still_Ongoing += count;
+}
 static void ClotDeath(int entity)
 {
 	InfectedMessenger npc = view_as<InfectedMessenger>(entity);

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_vile_poisonheadcrab_zombie.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_vile_poisonheadcrab_zombie.sp
@@ -257,13 +257,14 @@ public void ZSVILEPoisonheadcrabZombie_ClotThink(int iNPC)
 								
 								if(target > 0) 
 								{
+									if(!ShouldNpcDealBonusDamage(target))
 									{
-										if(!ShouldNpcDealBonusDamage(target))
-										SDKHooks_TakeDamage(target, npc.index, npc.index, 400.0, DMG_CLUB, -1, _, vecHit);
-									
-									else
-										SDKHooks_TakeDamage(target, npc.index, npc.index, 1000.0, DMG_CLUB, -1, _, vecHit);
 										Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 50 : 10);
+										SDKHooks_TakeDamage(target, npc.index, npc.index, 400.0, DMG_CLUB, -1, _, vecHit);
+									}
+									else
+									{
+										SDKHooks_TakeDamage(target, npc.index, npc.index, 1000.0, DMG_CLUB, -1, _, vecHit);
 									}
 									
 									// Hit particle

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/bosses/npc_zs_unspeakable.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/bosses/npc_zs_unspeakable.sp
@@ -317,6 +317,7 @@ methodmap ZsUnspeakable < CClotBody
 		npc.m_flVoidPillarAttack =  GetGameTime() + 5.0;
 		AlreadySaidWin = false;
 		AlreadySaidLastmann = false;
+		WaveStart_SubWaveStart(GetGameTime() + 1000.0);
 
 		func_NPCDeath[npc.index] = view_as<Function>(ZsUnspeakable_NPCDeath);
 		func_NPCOnTakeDamage[npc.index] = view_as<Function>(ZsUnspeakable_OnTakeDamage);
@@ -804,7 +805,10 @@ public Action ZsUnspeakable_OnTakeDamage(int victim, int &attacker, int &inflict
 				npc.m_bAlliesSummoned = true;
 				Spawn_Zombie(npc);
 			}
-			CPrintToChatAll("{crimson}불결한 존재{default}: 들린다... 너희의 육신이 부패하고, 심장이 멎는 그 소리가!");
+			
+			RaidModeTime += 30.0;
+			ApplyStatusEffect(victim, victim, "Unstoppable Force", 8.0);
+			CPrintToChatAll("{crimson}불결한 존재{default}: 너희는 그 무엇 하나 바꿀 수 없으리라.");
 			RaidModeScaling *= 1.1;
 		}
 	}

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/npc_zs_ally_heavy.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/npc_zs_ally_heavy.sp
@@ -452,6 +452,7 @@ void AllyheavySelfDefense(Allyheavy npc)
 					SDKHooks_TakeDamage(target, npc.index, npc.index, damageDealt, DMG_BULLET, -1, _, vecHit);
 					if (!IsInvuln(target) && !i_IsABuilding[target])
 					{
+						ApplyStatusEffect(npc.index, target, "Hypodermic Toxin Injection", 2.0);
 						if(!HasSpecificBuff(target, "Fluid Movement"))
 							ApplyStatusEffect(npc.index, target, "Slowdown", 1.0);
 					}

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/npc_zs_ally_sniper.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/npc_zs_ally_sniper.sp
@@ -402,6 +402,10 @@ int AllySniperSelfDefense(AllySniper npc, float gameTime)
 					damageDealt *= 3.0;
 				
 				SDKHooks_TakeDamage(target, npc.index, npc.index, damageDealt, DMG_BULLET, -1, _, ThrowPos[npc.index]);
+				if (!IsInvuln(target) && !i_IsABuilding[target])
+				{
+					ApplyStatusEffect(npc.index, target, "Silenced", 3.0);
+				}
 			} 
 		}
 	}

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_random_poyo.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_random_poyo.sp
@@ -28,9 +28,10 @@ static void ClotPrecache()
 	NPC_GetByPlugin("npc_zs_howler");
 	NPC_GetByPlugin("npc_zs_zombine");
 	NPC_GetByPlugin("npc_zs_bonemesh");
+	NPC_GetByPlugin("npc_zs_soldier_giant_grave");
 }
 
-bool SamePoyoDisallow[9];
+bool SamePoyoDisallow[11];
 static any ClotSummon(int client, float vecPos[3], float vecAng[3], int team, const char[] data)
 {
 	return PoyoSummonRandom(vecPos, vecAng, team, data);
@@ -148,6 +149,16 @@ void PoyoSummonRaidboss(int ZombieSummonbase)
 		case 8:
 		{
 			PluginName = "npc_zs_bonemesh";
+			enemy.Is_Boss = 1;
+		}
+		case 9:
+		{
+			PluginName = "npc_zs_soldier_giant_grave";
+			enemy.Is_Boss = 1;
+		}
+		case 10:
+		{
+			PluginName = "npc_zs_red_marrow";
 			enemy.Is_Boss = 1;
 		}
 	}

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_zs_poisonzombie_fortified_giant.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_zs_poisonzombie_fortified_giant.sp
@@ -252,18 +252,21 @@ public void ZSFortifiedGiantPoisonZombie_ClotThink(int iNPC)
 								{
 									
 									if(!ShouldNpcDealBonusDamage(target))
-										SDKHooks_TakeDamage(target, npc.index, npc.index, 160.0, DMG_CLUB, -1, _, vecHit);
-									
-									else
-										SDKHooks_TakeDamage(target, npc.index, npc.index, 240.0, DMG_CLUB, -1, _, vecHit);
-									// Hit particle
-									Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 500 : 500);
-									if(Armor_Charge[target] > 0)
 									{
-										Armor_Charge[target]=0;
-										f_Armor_BreakSoundDelay[target] = GetGameTime() + 5.0;	
-										EmitSoundToClient(target, "npc/assassin/ball_zap1.wav", target, SNDCHAN_STATIC, 60, _, 1.0, GetRandomInt(95,105));
+										SDKHooks_TakeDamage(target, npc.index, npc.index, 160.0, DMG_CLUB, -1, _, vecHit);
+										Elemental_AddPheromoneDamage(target, npc.index, npc.index ? 500 : 500);
+										if(Armor_Charge[target] > 0)
+										{
+											Armor_Charge[target]=0;
+											f_Armor_BreakSoundDelay[target] = GetGameTime() + 5.0;	
+											EmitSoundToClient(target, "npc/assassin/ball_zap1.wav", target, SNDCHAN_STATIC, 60, _, 1.0, GetRandomInt(95,105));
+										}
 									}
+									else
+									{
+										SDKHooks_TakeDamage(target, npc.index, npc.index, 240.0, DMG_CLUB, -1, _, vecHit);
+									}
+									// Hit particle
 									// Hit sound
 									npc.PlayMeleeHitSound();
 									

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_zs_red_marrow.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_zs_red_marrow.sp
@@ -35,6 +35,10 @@ static const char g_MeleeMissSounds[][] = {
 	"npc/fast_zombie/claw_miss2.wav",
 };
 float g_flRedMarrowAccumulatedDamage[2048]; 
+
+// [추가] 50% 체력 기믹이 단 한 번만 발동하도록 체크하는 전역 배열 플래그
+bool g_bRedMarrowTriggered50[2048]; 
+
 public void RedMarrow_OnMapStart_NPC()
 {
 	for (int i = 0; i < (sizeof(g_DeathSounds));	   i++) { PrecacheSound(g_DeathSounds[i]);	   }
@@ -107,6 +111,7 @@ methodmap RedMarrow < CClotBody
 		if(npc.index > 0 && npc.index < 2048)
         {
             g_flRedMarrowAccumulatedDamage[npc.index] = 0.0;
+            g_bRedMarrowTriggered50[npc.index] = false; // [변경] 생성 시 플래그 초기화
         }
 
 		npc.m_flNextMeleeAttack = 0.0;
@@ -119,8 +124,6 @@ methodmap RedMarrow < CClotBody
 		func_NPCDeath[npc.index] = RedMarrow_NPCDeath;
 		func_NPCThink[npc.index] = RedMarrow_ClotThink;
 		func_NPCOnTakeDamage[npc.index] = RedMarrow_OnTakeDamage;
-		
-		AddNpcToAliveList(npc.index, 1);
 		
 		float wave = float(Waves_GetRoundScale()+1); //Wave scaling
 		
@@ -268,37 +271,35 @@ public Action RedMarrow_OnTakeDamage(int victim, int &attacker, int &inflictor, 
     if(attacker <= 0 || victim <= 0 || !IsValidEntity(victim))
         return Plugin_Continue;
 
-    // 2. 최대 체력 가져오기 (npc.iMaxHealth 에러 시 대체제)
-    int maxHealth = GetEntProp(victim, Prop_Data, "m_iMaxHealth");
-    float threshold = float(maxHealth) * 0.25;
-
-    if (threshold <= 0.0) return Plugin_Continue;
-
-    // 3. 데미지 누적 및 트리거 체크
-    g_flRedMarrowAccumulatedDamage[victim] += damage;
-    
     RedMarrow npc = view_as<RedMarrow>(victim);
+    
+    int maxHealth = GetEntProp(victim, Prop_Data, "m_iMaxHealth");
+    int currentHealth = GetEntProp(victim, Prop_Data, "m_iHealth");
+    
+    float expectedHealth = float(currentHealth) - damage;
+    float health50Percent = float(maxHealth) * 0.5;
 
-    while(!npc.Anger && g_flRedMarrowAccumulatedDamage[victim] >= threshold)
+    // [변경] npc.bTriggered50 대신 새로 만든 전역 배열 플래그 사용
+    if (!g_bRedMarrowTriggered50[victim] && expectedHealth <= health50Percent)
     {
-        g_flRedMarrowAccumulatedDamage[victim] -= threshold;
+        g_bRedMarrowTriggered50[victim] = true; // 단 한번만 실행되도록 플래그 변경
 
         if(!NpcStats_IsEnemySilenced(victim))
         {
-            // 속성값이 확실히 존재하는지 확인 후 적용
             npc.bXenoInfectedSpecialHurt = true;
             npc.flXenoInfectedSpecialHurtTime = GetGameTime() + 5.0;
             
-            ApplyStatusEffect(victim, victim, "Unstoppable Force", 5.0);
+            ApplyStatusEffect(victim, victim, "Unstoppable Force", 8.0);
             
             CreateTimer(5.0, RedMarrow_Revert_Resistance_Enable, EntIndexToEntRef(victim), TIMER_FLAG_NO_MAPCHANGE);
         }
     }
-	if((ReturnEntityMaxHealth(npc.index) * 0.05) >= GetEntProp(npc.index, Prop_Data, "m_iHealth") && !npc.Anger)
-	{
-		npc.Anger = true;
-	}
-    // 헤드샷 쿨다운 로직 (기존 유지)
+
+    if((float(maxHealth) * 0.05) >= expectedHealth && !npc.Anger)
+    {
+        npc.Anger = true;
+    }
+
     if (npc.m_flHeadshotCooldown < GetGameTime())
     {
         npc.m_flHeadshotCooldown = GetGameTime() + DEFAULT_HURTDELAY;
@@ -325,5 +326,9 @@ public void RedMarrow_NPCDeath(int entity)
 	{
 		npc.PlayDeathSound();	
 	}
-	if(entity > 0 && entity < 2048) g_flRedMarrowAccumulatedDamage[entity] = 0.0;
+	if(entity > 0 && entity < 2048) 
+	{
+		g_flRedMarrowAccumulatedDamage[entity] = 0.0;
+		g_bRedMarrowTriggered50[entity] = false; // [변경] 사망 시 플래그 초기화
+	}
 }


### PR DESCRIPTION
1. 웨이브

1) 크리퍼가 5 10 15 20 25 30 35 40 웨이브에서만 나오게 변경

2) 35웨이브에 나오던 약탈자 무리가 감염된 저격수 무리로 변경(약탈자들은 추후 패치때 등장 예정)

3) 40웨이브 보스 처치시 주는 자금량: 4500 -> 50000

4) 41웨이브 보스 체력: 7000000 -> 10000000

2. 좀비들

1. 페로몬 원소피해가 구조물에도 적용되는 이슈 수정

2. 포이즌 헤드크랩의 디버프가 구조물에도 적용되는 이슈 수정

3. 포이즌 헤드크랩에게 물렸을때 0.5초간 무적이 부여되고 뒤로 밀려남

4. 헤드크랩들이 받는 근접 피해가 2배 증가함

5. 맨해튼 앵무새 자폭 피해량: 1000 -> 5000

6. 감염된 전령병의 아군 소환 기믹이 변경됨 이제 전령병 몸에서 스폰이 아닌 40 웨이브 보스와 동일한 방식으로 스폰함
(???는 기존과 같은 방식으로 스폰)

7. 불결한 존재가 아군 엘리트 좀비를 소환하는 기믹때 8초간 무적 상태가 부여되고 광폭화 시간이 30초 추가됨

8. 아군 새대가리 헤비가 적에게 받는 피해가 20％ 증가하는 디버프를 걸음

9. 아군 새대가리 스나이퍼가 적에게 침묵 디버프를 걸음

10. 레드 머로우의 무적이 체력이 절반만 남았을때 딱 한번만 쓰게 변경되었고 무적 시간이 5초 -> 8초로 증가함 또한 레드 머로우도 메인적으로 바뀌면서 더 이상 레머만 살아 있을때 다음 웨이브로 넘어가지 않음

12. 감염된 엔지니어에게 피격시 8초간 받는 피해가 30% 증가하는 디버프를 받게 변경됨