### PR TITLE
Weapons A/S

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/downloads.cfg
+++ b/addons/sourcemod/configs/zombie_riot/downloads.cfg
@@ -140,6 +140,9 @@
 			
 		//	//maybe fix Download Issue
 		//	"sound/zombie_riot/victoria_1/40_wave_setup.mp3"		""
+			
+			//Artvin....
+			"sound/zombie_riot/victoria_1/40_wave_setup.mp3"		""
 		}
 		"playermodels"
 		{

--- a/addons/sourcemod/configs/zombie_riot/fast_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/fast_vesta.cfg
@@ -1864,6 +1864,17 @@
 	//		"author"	"Monster Siren Records"
 	//		"volume"	"1.4"
 	//	}
+	
+		//Artvin....
+		"override_setup"
+		{
+			"file"		"#zombiesurvival/victoria_1/40_wave_setup.mp3"
+			"time"		"124"
+			"download"	"1"
+			"name"		"Operation Lucent Arrowhead Lobby Theme"
+			"author"	"Monster Siren Records"
+			"volume"	"1.4"
+		}
 		
 		"music_1"
 		{

--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -788,13 +788,16 @@
 				
 				"classname"								"tf_weapon_sniperrifle"
 				"index"									"201"
-				"attributes"							"6 ; 1.3 ; 41 ; 1.5 ; 2 ; 6 ; 97 ; 1.0 ; 5003 ; 1 ; 5004 ; 1.0 ; 390 ; 1.0"
+				"attributes"							"6 ; 1.3 ; 41 ; 1.5 ; 2 ; 6.0 ; 97 ; 1.0 ; 5003 ; 1 ; 5004 ; 1.0 ; 390 ; 1.0"
 				"ammo"									"16"	//Sniper ammo
 				
 				"weapon_archetype"						"2"
 				"no_clip"								"1"
 				//The amount of damage that is reduced for every 1000 units, the default is 0.9
 				"damage_falloff"						"1.0" 
+				
+				"func_attack"							"Weapon_SniperRifle_M1"
+				"func_ontakedamage_deal"				"SniperRifle_NPCTakeDamage"
 				
 				"lag_comp"								"1"
 				"lag_comp_collision"					"0"
@@ -808,7 +811,7 @@
 				
 				"pap_1_classname"						"tf_weapon_sniperrifle"
 				"pap_1_index"							"851"
-				"pap_1_attributes"						"6 ; 1.5 ; 41 ; 1.5 ; 2 ; 20 ; 298 ; 2 ; 97 ; 1.0 ; 4057 ; 1"
+				"pap_1_attributes"						"6 ; 1.5 ; 41 ; 1.5 ; 2 ; 20.0 ; 298 ; 2 ; 97 ; 1.0 ; 5003 ; 1 ; 5004 ; 1.0 ; 390 ; 1.0"
 				"pap_1_ammo"							"16"	//Sniper ammo
 				
 				"pap_1_weapon_archetype"				"2"
@@ -827,11 +830,11 @@
 				
 				"pap_2_classname"						"tf_weapon_sniperrifle"
 				"pap_2_index"							"526"
-				"pap_2_attributes"						"305 ; 1 ; 6 ; 1.7 ; 2 ; 50 ; 298 ; 5 ; 97 ; 1.0 ; 4057 ; 1"
+				"pap_2_attributes"						"305 ; 1 ; 6 ; 1.7 ; 2 ; 50 ; 298 ; 5 ; 97 ; 1.0 ; 5003 ; 1 ; 5004 ; 1.0 ; 390 ; 1.0 ; 304 ; 1.1"
 				"pap_2_ammo"							"16"	//Sniper ammo
 
 				"pap_2_func_attack"						"Weapon_Anti_Material_Rifle"
-				"pap_2_func_ondeploy"					"Weapon_Anti_Material_Deploy"
+				"func_ontakedamage_deal"				"SniperRifle_NPCTakeDamage"
 				
 				"pap_2_weapon_archetype"				"2"
 				"pap_2_no_clip"							"1"
@@ -850,11 +853,11 @@
 				
 				"pap_3_classname"						"tf_weapon_sniperrifle"
 				"pap_3_index"							"526"
-				"pap_3_attributes"						"305 ; 1 ; 6 ; 1.4 ; 2 ; 85.0 ; 298 ; 5 ; 97 ; 1.0 ; 4057 ; 1"
+				"pap_3_attributes"						"305 ; 1 ; 6 ; 1.4 ; 2 ; 85.0 ; 298 ; 5 ; 97 ; 1.0 ; 5003 ; 1 ; 5004 ; 1.0 ; 390 ; 1.0 ; 304 ; 1.1"
 				"pap_3_ammo"							"16"	//Sniper ammo
 
 				"pap_3_func_attack"						"Weapon_Anti_Material_Rifle"
-				"pap_3_func_ondeploy"					"Weapon_Anti_Material_Deploy"
+				"func_ontakedamage_deal"				"SniperRifle_NPCTakeDamage"
 
 				"pap_3_weapon_archetype"				"2"
 				"pap_3_no_clip"							"1"
@@ -1172,7 +1175,7 @@
 				
 				
 				"pap_4_custom_name"						"Mini Semi Gun"
-				"pap_4_cost"							"12000"
+				"pap_4_cost"							"10000"
 				"pap_4_desc"							"SMG Pap 4"	//Final 1
 				
 				"pap_4_classname"						"tf_weapon_smg"
@@ -1190,6 +1193,7 @@
 				"pap_4_lag_comp_block_internal"			"1" //Idk why but i need this.
 				
 				"pap_4_papskip"							"2"	// Skips Pap 4 & 5
+				"pap_4_pappaths"						"2"
 				
 				
 				"pap_5_custom_name"						"H&K G36 Carbine"
@@ -1216,7 +1220,7 @@
 				"pap_5_lag_comp_dont_move_building"		"0"
 				"pap_5_lag_comp_block_internal"			"1"
 				
-				"pap_5_papskip"							"1"	// Skips Pap 4 & 5
+				"pap_5_pappaths"						"0"
 				
 				
 				"pap_6_custom_name"						"Maschinengewehr 42"
@@ -1246,7 +1250,54 @@
 				"pap_6_weapon_custom_size"				"0.9"
 				"pap_6_weapon_custom_size_viewmodel"	"0.9"
 				
-				"pap_6_papskip"							"1"	// Skips Pap 4 & 5
+				"pap_6_pappaths"						"0"
+				
+				"pap_7_custom_name"						"Custom Mini Semi Gun: Overheating FeedBack"
+				"pap_7_cost"							"2000"
+				"pap_7_desc"							"Custom Mini Semi Gun: Overheating FeedBack Desc"
+				
+				"pap_7_classname"						"tf_weapon_smg"
+				"pap_7_index"							"211"
+				"pap_7_attributes"						"45 ; 2 ; 2 ; 40.1 ; 6 ; 0.85 ; 303 ; -1 ; 106 ; 0.7 ; 834 ; 420"
+				"pap_7_ammo"							"18"
+				
+				"pap_7_weapon_archetype"				"4"
+				"pap_7_no_clip"							"1"
+				
+				"pap_7_func_attack"						"Weapon_Mini_Semi_Gun_OverheatingFeedBack_M1"
+				"pap_7_func_attack2"					"Weapon_Mini_Semi_Gun_OverheatingFeedBack_M2"
+				//"pap_2_func_ontakedamage_take"			"MajorSteam_Launcher_PlayerTakeDamage"
+				"pap_7_func_mapstart"					"Custom_Mini_Semi_Gun_MapStart"
+				
+				"pap_7_lag_comp"						"1"
+				"pap_7_lag_comp_collision"				"0"
+				"pap_7_lag_comp_extend_boundingbox"		"1"
+				"pap_7_lag_comp_dont_move_building"		"0"
+				"pap_7_lag_comp_block_internal"			"1"
+				
+				"pap_7_pappaths"						"0"
+				
+				"pap_8_custom_name"						"Custom Mini Semi Gun: Bullet Storm"
+				"pap_8_cost"							"2000"
+				"pap_8_desc"							"Custom Mini Semi Gun: Bullet Storm Desc"
+				
+				"pap_8_classname"						"tf_weapon_smg"
+				"pap_8_index"							"211"
+				"pap_8_attributes"						"45 ; 4.0 ; 2 ; 35.5 ; 6 ; 0.85 ; 298 ; 4 ; 303 ; -1 ; 106 ; 0.7 ; 834 ; 435"
+				"pap_8_ammo"							"18"
+				
+				"pap_8_weapon_archetype"				"4"
+				"pap_8_no_clip"							"1"
+				
+				"pap_8_func_attack"						"Weapon_Mini_Semi_Gun_BulletStorm_M1"
+				
+				"pap_8_lag_comp"						"1"
+				"pap_8_lag_comp_collision"				"0"
+				"pap_8_lag_comp_extend_boundingbox"		"1"
+				"pap_8_lag_comp_dont_move_building"		"0"
+				"pap_8_lag_comp_block_internal"			"1"
+				
+				"pap_8_pappaths"						"0"
 				
 				"npc_type"	"4"	// 1 = Melee, 2 = Pistol, 3 = Shotgun, 4 = SMG, 5 = AR2, 6 = RPG
 			}
@@ -1420,14 +1471,14 @@
 				"cost"			"700"
 				"desc" 			"Deagle Desc"
 
-				"classname"								"tf_weapon_shotgun_soldier"
+				"classname"								"tf_weapon_revolver"
 				"index"									"61"
-				"attributes"							"1 ; 6.6 ; 45 ; 0.1 ; 834 ; 411 ; 2 ; 4.0 ; 4 ; 1.17 ; 106 ; 0 ; 6 ; 1.2 ; 97 ; 1.0" 
+				"attributes"							"834 ; 411 ; 2 ; 4.0 ; 4 ; 1.17 ; 106 ; 0 ; 6 ; 1.2 ; 97 ; 1.0" 
 				"ammo"									"19"	//revolver ammo
 				
 				"func_attack2"							"Ability_Coin_Flip"
 				
-				"viewmodel_force_class"					"1" //1 is scout, i like the viewmodel, it fits
+				"viewmodel_force_class"					"9" //1 is scout, i like the viewmodel, it fits
 				
 				"weapon_archetype"						"2"
 				"damage_falloff"						"0.9"
@@ -1448,14 +1499,14 @@
 				"pap_1_cost"							"2500"
 				"pap_1_desc"							"Deagle Pap 1"
 				
-				"pap_1_classname"						"tf_weapon_shotgun_soldier"
+				"pap_1_classname"						"tf_weapon_revolver"
 				"pap_1_index"							"1006"
-				"pap_1_attributes"						"1 ; 3.3 ; 45 ; 0.2 ; 834 ; 411 ; 309 ; 1 ; 2 ; 13.5 ; 4 ; 1.7 ; 106 ; 0 ; 6 ; 1.2 ; 97 ; 1.0"  
+				"pap_1_attributes"						"834 ; 411 ; 309 ; 1 ; 2 ; 13.5 ; 4 ; 1.7 ; 106 ; 0 ; 6 ; 1.2 ; 97 ; 1.0"  
 				"pap_1_ammo"							"19"	//revolver ammo
 				
 				"pap_1_func_attack2"					"Ability_Coin_Flip2"
 				
-				"pap_1_viewmodel_force_class"			"1" //1 is scout, i like the viewmodel, it fits
+				"pap_1_viewmodel_force_class"			"9" //1 is scout, i like the viewmodel, it fits
 				
 				"pap_1_weapon_archetype"	"2"
 				"pap_1_damage_falloff"					"0.9"
@@ -1504,14 +1555,14 @@
 				"pap_3_cost"							"7000"
 				"pap_3_desc"							"Deagle Pap 2"
 				
-				"pap_3_classname"						"tf_weapon_shotgun_soldier"
+				"pap_3_classname"						"tf_weapon_revolver"
 				"pap_3_index"							"525"
-				"pap_3_attributes"						"1 ; 1.64 ; 45 ; 0.4 ; 834 ; 412 ; 309 ; 1 ; 2 ; 33.0 ; 4 ; 1.3 ; 106 ; 0 ; 6 ; 1.2 ; 97 ; 1.0 ; 4014 ; 1.0"    
+				"pap_3_attributes"						"834 ; 412 ; 309 ; 1 ; 2 ; 33.0 ; 4 ; 1.3 ; 106 ; 0 ; 6 ; 1.2 ; 97 ; 1.0 ; 4014 ; 1.0"    
 				"pap_3_ammo"							"19"	//revolver ammo
 				
 				"pap_3_func_attack2"					"Ability_Coin_Flip3"
 				
-				"pap_3_viewmodel_force_class"			"1" //1 is scout, i like the viewmodel, it fits
+				"pap_3_viewmodel_force_class"			"9" //1 is scout, i like the viewmodel, it fits
 				
 				"pap_3_weapon_archetype"				"4"
 				"pap_3_reload_mode"						"1"
@@ -1559,17 +1610,17 @@
 				"pap_5_cost"							"12000"
 				"pap_5_desc"							"Deagle Pap 3"
 				
-				"pap_5_classname"						"tf_weapon_shotgun_soldier"
+				"pap_5_classname"						"tf_weapon_revolver"
 				"pap_5_index"							"525"
 				//each upgrade makes the shots feel more meaty due to the additional bullets
-				"pap_5_attributes"						"1 ; 0.825 ; 45 ; 0.8 ; 834 ; 286 ; 309 ; 1 ; 2 ; 75.0 ; 4 ; 1.5 ; 106 ; 0 ; 6 ; 1.2 ; 97 ; 1.0 ; 4014 ; 1.0"  
+				"pap_5_attributes"						"834 ; 286 ; 309 ; 1 ; 2 ; 75.0 ; 4 ; 1.5 ; 106 ; 0 ; 6 ; 1.2 ; 97 ; 1.0 ; 4014 ; 1.0"  
 				"pap_5_ammo"							"19"	//revolver ammo
 				
 				"pap_5_func_attack"						"Weapon_BrainAnnihilator"
 				"pap_5_func_attack2"					"Ability_Coin_Flip4"
 				//"pap_5_func_weaponcreated"			"ForcePlay_CritSoundCreated"
 				
-				"pap_5_viewmodel_force_class"			"1" //1 is scout, i like the viewmodel, it fits
+				"pap_5_viewmodel_force_class"			"9" //1 is scout, i like the viewmodel, it fits
 				
 				"pap_5_weapon_archetype"				"2"
 				"pap_5_damage_falloff"					"0.9"
@@ -2810,9 +2861,6 @@
 				"pap_2_pappaths"					"1"
 				"pap_2_papskip"						"2"
 				
-				"pap_2_func_ontakedamage_take"		"MajorSteam_Launcher_PlayerTakeDamage"
-				
-				
 				"pap_3_desc"		"RPG Pap 2"
 				
 				"pap_3_cost"		"12500"
@@ -2877,9 +2925,6 @@
 				"pap_5_lag_comp_dont_move_building" "1"
 				
 				"pap_5_pappaths"					"0"
-				
-				"pap_5_func_ontakedamage_take"		"MajorSteam_Launcher_PlayerTakeDamage"
-				"pap_5_func_ontakedamage_deal"		"MajorSteam_Launcher_NPCTakeDamage"
 				
 				"npc_type"	"6"	// 1 = Melee, 2 = Pistol, 3 = Shotgun, 4 = SMG, 5 = AR2, 6 = RPG
 			}
@@ -11319,7 +11364,6 @@
 				"index"		"211"
 				"attributes"	"9 ; 1.0 ; 231 ; 1 ; 8 ; 1.3 ; 13 ; 99999 ; 2046 ; 1.0 ; 10 ; 0.0 ; 7 ; 0.8" // 2046, 1 = ally heal, 2 = enemy hurt, 3 = building heal
 				"func_attack3"	"MedigunChangeModeR"
-				"weapon_hud_extra" "[CROUCH + R]"
 
 
 
@@ -11337,60 +11381,60 @@
 				
 				//i dunno if i should, but i will just incase
 				
-				"pap_1_custom_name"		"적응형 메디건"
-				"pap_1_desc"		"Medigun Desc Pap 1"
+				"pap_1_custom_name"						"Adaptive Medigun"
+				"pap_1_desc"							"Medigun Desc Pap 1"
 				
-				"pap_1_cost"		"2000"
+				"pap_1_cost"							"2000"
 				
-				"pap_1_classname"	"tf_weapon_medigun"
-				"pap_1_index"		"998"
+				"pap_1_classname"						"tf_weapon_medigun"
+				"pap_1_index"							"998"
 
-				"pap_1_attributes"	"9 ; 1.0 ; 231 ; 1 ; 8 ; 1.3 ; 13 ; 99999 ; 2046 ; 5.0 ; 10 ; 0.0 ; 7 ; 0.8"
-				"pap_1_ammo"		"21"	//Medigun fluid Ammo
-				"pap_1_func_attack3"	"Adaptive_MedigunChangeBuff"
+				"pap_1_attributes"						"9 ; 1.0 ; 231 ; 1 ; 8 ; 1.3 ; 13 ; 99999 ; 2046 ; 5.0 ; 10 ; 0.0 ; 7 ; 0.8"
+				"pap_1_ammo"							"21"	//Medigun fluid Ammo
+				"pap_1_func_attack3"					"Adaptive_MedigunChangeBuff"
 				
-				"pap_1_lag_comp" 							"0"
+				"pap_1_lag_comp" 						"0"
 				"pap_1_lag_comp_collision" 				"1"		//Must be on 1 if you want the below
 				"pap_1_lag_comp_away_everything_enemy" 	"1"
-				"pap_1_lag_comp_extend_boundingbox" 		"0"
-				"pap_1_lag_comp_dont_move_building" 		"0" 
-				"pap_1_lag_comp_dont_allied_npc"			"1"
+				"pap_1_lag_comp_extend_boundingbox" 	"0"
+				"pap_1_lag_comp_dont_move_building" 	"0"
+				"pap_1_lag_comp_dont_allied_npc"		"1"
 				"pap_1_no_clip"							"1"
-				"pap_1_weapon_archetype"	"17"
-				"pap_1_pappaths"	"0"
-				"pap_1_papskip"		"22"
-				"pap_1_is_a_support"	"1"
-				"pap_1_slot"		"13" // 13 is medigun (uber bug bad fix lol)
-				"pap_1_weapon_hud_extra" "[CROUCH + R]"
+				"pap_1_weapon_archetype"				"17"
+				"pap_1_int_ability_onequip"				"1008"
+				"pap_1_pappaths"						"0"
+				"pap_1_papskip"							"22"
+				"pap_1_is_a_support"					"1"
+				"pap_1_slot"							"13" // 13 is medigun (uber bug bad fix lol)
+				"pap_1_weapon_hud_extra"				"[CROUCH + R]"
 				
 				
-				"pap_2_custom_name"		"아머 메디건"
-				"pap_2_desc"		"Medigun Desc Pap 2"
+				"pap_2_custom_name"						"Armor Medigun"
+				"pap_2_desc"							"Medigun Desc Pap 2"
 				
-				"pap_2_cost"		"2000"
+				"pap_2_cost"							"2000"
 				
-				"pap_2_classname"	"tf_weapon_medigun"
-				"pap_2_index"		"211"
-
-				"pap_2_attributes"	"9 ; 1.0 ; 231 ; 1 ; 8 ; 1.3 ; 13 ; 99999 ; 2046 ; 6.0 ; 10 ; 0.0 ; 834 ; 218 ; 7 ; 0.8"
-				"pap_2_ammo"		"21"	//Medigun fluid Ammo
+				"pap_2_classname"						"tf_weapon_medigun"
+				"pap_2_index"							"211"
 				
-				"pap_2_lag_comp" 							"0"
+				"pap_2_attributes"						"9 ; 1.0 ; 231 ; 1 ; 8 ; 1.3 ; 13 ; 99999 ; 2046 ; 6.0 ; 10 ; 0.0 ; 834 ; 218 ; 7 ; 0.8"
+				"pap_2_ammo"							"21"	//Medigun fluid Ammo
+				
+				"pap_2_lag_comp" 						"0"
 				"pap_2_lag_comp_collision" 				"1"		//Must be on 1 if you want the below
 				"pap_2_lag_comp_away_everything_enemy" 	"1"
-				"pap_2_lag_comp_extend_boundingbox" 		"0"
-				"pap_2_lag_comp_dont_move_building" 		"0" 
-				"pap_2_lag_comp_dont_allied_npc"			"1"
+				"pap_2_lag_comp_extend_boundingbox" 	"0"
+				"pap_2_lag_comp_dont_move_building" 	"0" 
+				"pap_2_lag_comp_dont_allied_npc"		"1"
 				"pap_2_no_clip"							"1"
-				"pap_2_weapon_archetype"	"17"
-				"pap_2_pappaths"	"0"
-				"pap_2_papskip"		"22"
-				"pap_2_is_a_support"	"1"
-				"pap_2_slot"		"13" // 13 is medigun (uber bug bad fix lol)
-				"pap_2_func_attack3"	"MedigunChangeModeR"
-				"pap_2_weapon_hud_extra" "[CROUCH + R]"
+				"pap_2_weapon_archetype"				"17"
+				"pap_2_pappaths"						"0"
+				"pap_2_papskip"							"22"
+				"pap_2_is_a_support"					"1"
+				"pap_2_slot"							"13" // 13 is medigun (uber bug bad fix lol)
+				"pap_2_func_attack3"					"MedigunChangeModeR"
 				
-				"pap_3_custom_name"						"과부하 메디건"
+				"pap_3_custom_name"						"Overclocking Devices"
 				"pap_3_desc"							"Medigun Desc Pap 3"
 
 				"pap_3_cost"							"2000"
@@ -11413,7 +11457,6 @@
 				"pap_3_is_a_support"					"1"
 				"pap_3_slot"		"13" // 13 is medigun (uber bug bad fix lol
 				"pap_3_func_attack3"	"MedigunChangeModeR"
-				"pap_3_weapon_hud_extra" "[CROUCH + R]"
 			}
 			"The Health Hose"
 			{

--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -778,23 +778,23 @@
 				
 				"classname"	"tf_weapon_sniperrifle"
 				"index"		"201"
-				"attributes"	"6 ; 1.3 ; 41 ; 1.5 ; 2 ; 6 ; 97 ; 1.0 ; 4057 ; 1"
+				"attributes"	"6 ; 1.3 ; 41 ; 1.5 ; 2 ; 6.0 ; 97 ; 1.0 ; 5003 ; 1"
 				
 				"ammo"		"16"	//Sniper ammo
 
 
 
 				
-				"damage_falloff"	"1.0" //The amount of damage that is reduced for every 1000 units, the default is 0.9
+				"damage_falloff"				"1.0" //The amount of damage that is reduced for every 1000 units, the default is 0.9
 				"lag_comp" 						"1"
-				"lag_comp_collision" 		"0"
-				"lag_comp_extend_boundingbox" 		"1"
+				"lag_comp_collision" 			"0"
+				"lag_comp_extend_boundingbox" 	"1"
 				"lag_comp_dont_move_building" 	"0"
 				"no_clip"						"1"
-				"weapon_archetype"	"2"
+				"weapon_archetype"				"2"
 				
 				
-				"pap_1_custom_name"		"대구경 저격소총"
+				"pap_1_custom_name"		"Heavy Caliber Sniper Rifle"
 				
 				"pap_1_desc"		"Sniper Rifle Pap 1"
 				
@@ -802,7 +802,7 @@
 				
 				"pap_1_classname"	"tf_weapon_sniperrifle"
 				"pap_1_index"		"851"
-				"pap_1_attributes"	"6 ; 1.5 ; 41 ; 1.5 ; 2 ; 20 ; 298 ; 2 ; 97 ; 1.0 ; 4057 ; 1"
+				"pap_1_attributes"	"6 ; 1.5 ; 41 ; 1.5 ; 2 ; 20 ; 298 ; 2 ; 97 ; 1.0 ; 5003 ; 1"
 				"pap_1_ammo"		"16"	//Sniper ammo
 
 

--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -775,15 +775,16 @@
 				"starter"	"1"
 				"cost"		"600"
 				"author"	"Artvin"
+				"desc"		"Sniper Rifle Desc"
 				
 				"classname"	"tf_weapon_sniperrifle"
 				"index"		"201"
-				"attributes"	"6 ; 1.3 ; 41 ; 1.5 ; 2 ; 6.0 ; 97 ; 1.0 ; 5003 ; 1"
+				"attributes"	"6 ; 1.3 ; 41 ; 1.5 ; 2 ; 6.0 ; 97 ; 1.0 ; 5003 ; 1 ; 5004 ; 1.0 ; 390 ; 1.0"
 				
 				"ammo"		"16"	//Sniper ammo
 
-
-
+				"func_attack"					"Weapon_SniperRifle_M1"
+				"func_ontakedamage_deal"		"SniperRifle_NPCTakeDamage"
 				
 				"damage_falloff"				"1.0" //The amount of damage that is reduced for every 1000 units, the default is 0.9
 				"lag_comp" 						"1"
@@ -794,7 +795,7 @@
 				"weapon_archetype"				"2"
 				
 				
-				"pap_1_custom_name"		"Heavy Caliber Sniper Rifle"
+				"pap_1_custom_name"	"Sniper Rifle - pap1"
 				
 				"pap_1_desc"		"Sniper Rifle Pap 1"
 				
@@ -802,11 +803,11 @@
 				
 				"pap_1_classname"	"tf_weapon_sniperrifle"
 				"pap_1_index"		"851"
-				"pap_1_attributes"	"6 ; 1.5 ; 41 ; 1.5 ; 2 ; 20 ; 298 ; 2 ; 97 ; 1.0 ; 5003 ; 1"
+				"pap_1_attributes"	"6 ; 1.5 ; 41 ; 1.5 ; 2 ; 20 ; 298 ; 2 ; 97 ; 1.0 ; 5003 ; 1 ; 5004 ; 1.0 ; 390 ; 1.0"
 				"pap_1_ammo"		"16"	//Sniper ammo
 
-
-
+				"pap_1_func_attack"				"Weapon_SniperRifle_M1"
+				"pap_1_func_ontakedamage_deal"	"SniperRifle_NPCTakeDamage"
 				
 				"pap_1_lag_comp" 						"1"
 				"pap_1_lag_comp_collision" 		"0"

--- a/addons/sourcemod/scripting/shared/attributes.sp
+++ b/addons/sourcemod/scripting/shared/attributes.sp
@@ -75,6 +75,8 @@ enum
 	Attrib_MaxArmor_Multiplier = 5000,
 	Attrib_MaxArmor_BaseAdditive = 5001,
 	Attrib_MaxArmor_FinalAdditive = 5002,
+	Attrib_IsSniperRifle = 5003,
+	Attrib_ExplosiveHeadshot = 5004,
 };
 
 StringMap WeaponAttributes[MAXENTITIES + 1];

--- a/addons/sourcemod/scripting/shared/core.sp
+++ b/addons/sourcemod/scripting/shared/core.sp
@@ -3826,7 +3826,11 @@ void ReviveClientFromOrToEntity(int target, int client, int extralogic = 0, int 
 	if(medigun > 0)
 	{
 		speed = RoundToNearest(float(speed) * 0.65);
+		if(HasSpecificBuff(client, "Inspire"))
+			speed *= RoundToNearest(float(speed) * (1.0/0.65));
 	}
+	else if(HasSpecificBuff(client, "Inspire"))
+		speed *= 2;
 	if(HasSpecificBuff(client, "Dimensional Turbulence"))
 	{
 		speed *= 2;

--- a/addons/sourcemod/scripting/shared/custom/joke_medigun_mod_drain_health.sp
+++ b/addons/sourcemod/scripting/shared/custom/joke_medigun_mod_drain_health.sp
@@ -94,7 +94,7 @@ bool NeedCrouchAbility(int client)
 public void MedigunChangeModeR(int client, int weapon, bool crit, int slot)
 {
 
-	MedigunChangeModeRInternal(client, weapon, crit, slot, NeedCrouchAbility(client));
+	MedigunChangeModeRInternal(client, weapon, crit, slot, false);
 }
 public void MedigunChangeModeRInternal(int client, int weapon, bool crit, int slot, bool checkCrouch)
 {
@@ -251,6 +251,26 @@ public void GiveMedigunBuffUber(int medigun, int owner, int receiver)
 				TF2_AddCondition(receiver, TFCond_Kritzkrieged, UBERCHARGE_BUFFDURATION);
 			}
 			ApplyStatusEffect(owner, receiver, "Weapon Overclock", UBERCHARGE_BUFFDURATION);
+		}
+		case WEAPON_ADAPTIVE_MEDIGUN:
+		{
+			if(IsValidClient(receiver))
+			{
+				TF2_AddCondition(receiver, TFCond_UberBulletResist, UBERCHARGE_BUFFDURATION);
+				TF2_AddCondition(receiver, TFCond_UberBlastResist, UBERCHARGE_BUFFDURATION);
+				TF2_AddCondition(receiver, TFCond_UberFireResist, UBERCHARGE_BUFFDURATION);
+				if(dieingstate[receiver] > 0)
+				{
+					if(i_CurrentEquippedPerk[owner] & PERK_REGENE)
+						SetEntityHealth(receiver,  GetClientHealth(receiver) + 6);
+					else
+						SetEntityHealth(receiver,  GetClientHealth(receiver) + 3);
+					if(dieingstate[owner] > 0)
+						dieingstate[receiver] -= RoundToNearest(float(Adaptive_FastRevive(owner))*0.65);
+				}
+			}
+			ApplyStatusEffect(owner, receiver, "Inspire", UBERCHARGE_BUFFDURATION);
+			ApplyStatusEffect(owner, receiver, "UBERCHARGED", UBERCHARGE_BUFFDURATION);
 		}
 		default:
 		{
@@ -673,17 +693,17 @@ float MedigunGetUberDuration(int owner)
 public void Adaptive_MedigunChangeBuff(int client, int weapon, bool crit, int slot)
 {
 	//only swithc with crouch R
-	if((GetClientButtons(client) & IN_DUCK))
+	if(NeedCrouchAbility(client))
 	{
-		ClientCommand(client, "playgamesound weapons/vaccinator_toggle.wav");
-		MedigunModeSet[client]++;
-		if(MedigunModeSet[client] > 1)
-		{
-			MedigunModeSet[client] = 0;
-		}
+		MedigunChangeModeRInternal(client, weapon, crit, slot, NeedCrouchAbility(client));
 		return;
 	}
-	MedigunChangeModeRInternal(client, weapon, crit, slot, false);
+	ClientCommand(client, "playgamesound weapons/vaccinator_toggle.wav");
+	MedigunModeSet[client]++;
+	if(MedigunModeSet[client] > 1)
+	{
+		MedigunModeSet[client] = 0;
+	}
 }
 
 

--- a/addons/sourcemod/scripting/shared/damage.sp
+++ b/addons/sourcemod/scripting/shared/damage.sp
@@ -2054,6 +2054,14 @@ static stock bool OnTakeDamageBackstab(int victim, int &attacker, int &inflictor
 			{
 				damage *= 1.25;
 			}
+			float attrib = Attributes_Get(weapon, Attrib_ExplosiveHeadshot, 0.0);
+			if(attrib >= 1.0)
+			{
+				float WorldSpaceVec[3]; WorldSpaceCenter(victim, WorldSpaceVec);
+				SpawnSmallExplosion(WorldSpaceVec);
+				Explode_Logic_Custom(damage, attacker, attacker, -1, WorldSpaceVec);
+				damage*=0.0;
+			}
 		}
 		else
 		{

--- a/addons/sourcemod/scripting/shared/damage.sp
+++ b/addons/sourcemod/scripting/shared/damage.sp
@@ -2054,14 +2054,6 @@ static stock bool OnTakeDamageBackstab(int victim, int &attacker, int &inflictor
 			{
 				damage *= 1.25;
 			}
-			float attrib = Attributes_Get(weapon, Attrib_ExplosiveHeadshot, 0.0);
-			if(attrib >= 1.0)
-			{
-				float WorldSpaceVec[3]; WorldSpaceCenter(victim, WorldSpaceVec);
-				SpawnSmallExplosion(WorldSpaceVec);
-				Explode_Logic_Custom(damage, attacker, attacker, -1, WorldSpaceVec);
-				damage*=0.0;
-			}
 		}
 		else
 		{

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -802,6 +802,26 @@ void StatusEffects_Baka()
 	data.Status_SpeedFunc 			= INVALID_FUNCTION;
 	data.HudDisplay_Func 				= SupportWeapon_Func;
 	StatusEffect_AddGlobal(data);
+
+	strcopy(data.BuffName, sizeof(data.BuffName), "Inspire");
+	strcopy(data.HudDisplay, sizeof(data.HudDisplay), "✚");
+	strcopy(data.AboveEnemyDisplay, sizeof(data.AboveEnemyDisplay), "");
+	//-1.0 means unused
+	data.DamageTakenMulti 			= -1.0;
+	data.DamageDealMulti				= -1.0;
+	data.AttackspeedBuff				= -1.0;
+	data.MovementspeedModif			= -1.0;
+	data.Positive 					= true;
+	data.ShouldScaleWithPlayerCount 	= false;
+	data.Slot						= 0;
+	data.SlotPriority					= 0;
+	data.OnTakeDamage_TakenFunc 		= INVALID_FUNCTION;
+	data.OnTakeDamage_DealFunc 		= INVALID_FUNCTION;
+	data.OnTakeDamage_PostVictim		= INVALID_FUNCTION;
+	data.OnTakeDamage_PostAttacker		= INVALID_FUNCTION;
+	data.Status_SpeedFunc 			= INVALID_FUNCTION;
+	data.HudDisplay_Func 				= INVALID_FUNCTION;
+	StatusEffect_AddGlobal(data);
 }
 
 float AOESlowdown_Func(int victim, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)

--- a/addons/sourcemod/scripting/zombie_riot/custom/addons/m3_base.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/addons/m3_base.sp
@@ -562,9 +562,12 @@ static void DrinkRND(int client, int Overrides=-1)
 			}
 			case 18:
 			{
-				Armor_Charge[client]=0;
-				f_Armor_BreakSoundDelay[client] = GameTime + 5.0;	
-				EmitSoundToClient(client, "npc/assassin/ball_zap1.wav", client, SNDCHAN_STATIC, 60, _, 1.0, GetRandomInt(95,105));
+				if(Armor_Charge[client] > 0)
+				{
+					Armor_Charge[client]=0;
+					f_Armor_BreakSoundDelay[client] = GameTime + 5.0;	
+					EmitSoundToClient(client, "npc/assassin/ball_zap1.wav", client, SNDCHAN_STATIC, 60, _, 1.0, GetRandomInt(95,105));
+				}
 				return;
 			}
 			case 19:

--- a/addons/sourcemod/scripting/zombie_riot/custom/addons/weapon_mini_semi_gun.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/addons/weapon_mini_semi_gun.sp
@@ -1,0 +1,151 @@
+#pragma semicolon 1
+#pragma newdecls required
+static float OverheatingFeedBack_RestTime[MAXPLAYERS];
+static float OverheatingFeedBack_HudTime[MAXPLAYERS];
+static int OverheatingFeedBack_Charge[MAXPLAYERS];
+static int OverheatingFeedBack_Sounds[MAXPLAYERS];
+static bool OverheatingFeedBack_FullCharge[MAXPLAYERS];
+static bool OverheatingFeedBack_Overclocking[MAXPLAYERS];
+
+static const char Minisemi_SoundLists[][] = {
+	"weapons/sniper_railgun_bolt_back.wav",
+	"weapons/syringegun_reload_air2.wav",
+	"weapons/syringegun_reload_air1.wav",
+	"misc/hologram_start.wav",
+	"items/powerup_pickup_reflect_reflect_damage.wav"
+};
+
+public void Custom_Mini_Semi_Gun_MapStart()
+{
+	Zero(OverheatingFeedBack_Sounds);
+	Zero(OverheatingFeedBack_Charge);
+	Zero(OverheatingFeedBack_FullCharge);
+	Zero(OverheatingFeedBack_Overclocking);
+	ZeroFloat(OverheatingFeedBack_RestTime);
+	ZeroFloat(OverheatingFeedBack_HudTime);
+	
+	PrecacheSoundArray(Minisemi_SoundLists);
+}
+
+public void Weapon_Mini_Semi_Gun_OverheatingFeedBack_M1(int client, int weapon, bool crit, int slot)
+{
+	float GameTime = GetGameTime();
+	if(OverheatingFeedBack_RestTime[client] < GameTime)
+	{
+		if(TF2_IsPlayerInCondition(client, TFCond_FocusBuff))
+			TF2_RemoveCondition(client, TFCond_FocusBuff);
+		OverheatingFeedBack_Charge[client]=0;
+		OverheatingFeedBack_Sounds[client]=0;
+		OverheatingFeedBack_FullCharge[client]=false;
+		CreateTimer(0.1, Timer_ChangeStartSound, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE|TIMER_REPEAT);
+	}
+	OverheatingFeedBack_Charge[client]+=(OverheatingFeedBack_Overclocking[client] ? 2 : 1);
+	if(OverheatingFeedBack_Charge[client] > (OverheatingFeedBack_Overclocking[client] ? 600 : 300))
+		OverheatingFeedBack_Charge[client]=(OverheatingFeedBack_Overclocking[client] ? 600 : 300);
+	if(OverheatingFeedBack_Overclocking[client] && OverheatingFeedBack_Charge[client] < 300)
+		OverheatingFeedBack_Charge[client]+=2;
+		
+	if(Ability_Check_Cooldown(client, 1) <= 0.0 && OverheatingFeedBack_Overclocking[client])
+		OverheatingFeedBack_Overclocking[client]=false;
+		
+	float Ratio =  float(OverheatingFeedBack_Charge[client])/300.0;
+
+	if(Ratio > (OverheatingFeedBack_Overclocking[client] ? 2.0 : 1.0))
+		Ratio = (OverheatingFeedBack_Overclocking[client] ? 2.0 : 1.0);
+	SetGlobalTransTarget(client);
+	if(Ratio==(OverheatingFeedBack_Overclocking[client] ? 2.0 : 1.0))
+	{
+		if(OverheatingFeedBack_HudTime[client]<GameTime)
+		{
+			TF2_AddCondition(client, TFCond_FocusBuff, Attributes_Get(weapon, 6, 0.25) *0.4);
+			OverheatingFeedBack_HudTime[client] = GameTime+0.5;
+			if(OverheatingFeedBack_Overclocking[client])
+				PrintHintText(client, "%t",
+				"Custom Mini Semi Gun: Overheating FeedBack - Overclocking MAX");
+			else
+				PrintHintText(client, "%t",
+				"Custom Mini Semi Gun: Overheating FeedBack - MAX");
+		}
+		if(!OverheatingFeedBack_FullCharge[client])
+		{
+			EmitSoundToClient(client, Minisemi_SoundLists[3]);
+			OverheatingFeedBack_FullCharge[client]=true;
+		}
+	}
+	else
+	{
+		if(OverheatingFeedBack_HudTime[client]<GameTime)
+		{
+			OverheatingFeedBack_HudTime[client] = GameTime+0.5;
+			if(OverheatingFeedBack_Overclocking[client])
+				PrintHintText(client, "%t [%.0f％]",
+				"Custom Mini Semi Gun: Overheating FeedBack - Overclocking Charge",100.0*Ratio);
+			else
+				PrintHintText(client, "%t [%.0f％]",
+				"Custom Mini Semi Gun: Overheating FeedBack - Charge",100.0*Ratio);
+		}
+	}
+	OverheatingFeedBack_RestTime[client] = GameTime + Attributes_Get(weapon, 6, 0.25) *0.4;
+	Attributes_Set(weapon, 1, Ratio+1.0);
+	float spread = 0.7-(0.35*Ratio);
+	if(spread < 0.3)spread = 0.3;
+	Attributes_Set(weapon, 106, spread);
+}
+
+public void Weapon_Mini_Semi_Gun_OverheatingFeedBack_M2(int client, int weapon, bool crit, int slot)
+{
+	float Ability_CD = Ability_Check_Cooldown(client, slot);
+	if(Ability_CD <= 0.0 || CvarInfiniteCash.BoolValue)
+		Ability_CD = 0.0;
+	if(Ability_CD || OverheatingFeedBack_Overclocking[client])
+	{
+		ClientCommand(client, "playgamesound items/medshotno1.wav");
+		SetDefaultHudPosition(client);
+		SetGlobalTransTarget(client);
+		ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Ability has cooldown", Ability_CD);
+		return;
+	}
+	float SetCoolDown = 15.0+(60.0 * CooldownReductionAmount(client));
+	Rogue_OnAbilityUse(client, weapon);
+	Ability_Apply_Cooldown(client, slot, SetCoolDown, .ignoreCooldown=true);
+	Ability_Apply_Cooldown(client, 1, 15.0, .ignoreCooldown=true);
+	EmitSoundToClient(client, Minisemi_SoundLists[4]);
+	OverheatingFeedBack_Overclocking[client]=true;
+}
+
+/*public void Weapon_Mini_Semi_Gun_BulletStorm_Enable(int client, int weapon)
+{
+	
+}*/
+
+public void Weapon_Mini_Semi_Gun_BulletStorm_M1(int client, int weapon, bool crit, int slot)
+{
+	TF2_StunPlayer(client, (Attributes_Get(weapon, 6, 0.25)*0.4), 1.0, TF_STUNFLAG_NOSOUNDOREFFECT|TF_STUNFLAG_SLOWDOWN, client);
+}
+
+static Action Timer_ChangeStartSound(Handle timer, any userid)
+{
+	int client = GetClientOfUserId(userid);
+	if(!IsValidClient(client) && !IsPlayerAlive(client))
+		return Plugin_Stop;
+	switch(OverheatingFeedBack_Sounds[client])
+	{
+		case 0:
+		{
+			EmitSoundToAll(Minisemi_SoundLists[0], client, SNDCHAN_AUTO, 65, _, 1.0, 115);
+			OverheatingFeedBack_Sounds[client]++;
+		}
+		case 1:
+		{
+			EmitSoundToAll(Minisemi_SoundLists[1], client, SNDCHAN_AUTO, 65, _, 0.9, 115);
+			OverheatingFeedBack_Sounds[client]++;
+		}
+		default:
+		{
+			EmitSoundToAll(Minisemi_SoundLists[2], client, SNDCHAN_AUTO, 65, _, 0.9, 115);
+			OverheatingFeedBack_Sounds[client]=0;
+			return Plugin_Stop;
+		}
+	}
+	return Plugin_Continue;
+}

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_blacksmith.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_blacksmith.sp
@@ -538,7 +538,7 @@ void Blacksmith_BuildingUsed_Internal(int weapon ,int entity, int client, int ow
 				if(Attributes_Get(weapon, Attrib_IsSniperRifle, 0.0) != 0.0)
 				{
 					BlockNormal = true;
-					switch(GetURandomInt() % 4)
+					switch(GetURandomInt() % 6)
 					{
 						case 0:
 							Tinker_SR_ExplosiveHeadshot(tinker.Rarity, tinker);
@@ -550,6 +550,10 @@ void Blacksmith_BuildingUsed_Internal(int weapon ,int entity, int client, int ow
 							Tinker_SR_DepletedUranium(tinker.Rarity, tinker);
 						case 4:
 							Tinker_SR_HighSpeedFeedMechanism(tinker.Rarity, tinker);
+						case 5:
+							Tinker_SR_HollowPointBullets(tinker.Rarity, tinker);
+						default:
+							Tinker_SR_ExplosiveHeadshot(tinker.Rarity, tinker);
 					}
 				}
 			}
@@ -1103,8 +1107,11 @@ void Blacksmith_PrintAttribValue(int client, int attrib, float value, float luck
 		case Attrib_ExplosiveHeadshot:
 			Format(buffer, sizeof(buffer), "%s 폭발성 헤드샷 피해량", buffer);
 			
-		case 305:
+		case 304:
 			Format(buffer, sizeof(buffer), "%s 완전 충전 시 피해량", buffer);
+			
+		case 390:
+			Format(buffer, sizeof(buffer), "%s 헤드샷 피해량", buffer);
 	}
 	
 	CPrintToChat(client, "%s {yellow}(%d％)", buffer, RoundToCeil(luck * 100.0));
@@ -2076,9 +2083,9 @@ static void Tinker_SR_ExplosiveHeadshot(int rarity, TinkerEnum tinker)
 
 	switch(rarity)
 	{
-		case 0:{tinker.Value[0] = 1.0 + EHSLuck;tinker.Value[1] = 0.6 + DamageLuck;tinker.Value[2] = 2.5 - AttackSpeedLuck;}
-		case 1:{tinker.Value[0] = 1.25 + EHSLuck;tinker.Value[1] = 0.7 + DamageLuck;tinker.Value[2] = 2.0 - AttackSpeedLuck;}
-		case 2:{tinker.Value[0] = 1.5 + EHSLuck;tinker.Value[1] = 0.8 + DamageLuck;tinker.Value[2] = 1.85 - AttackSpeedLuck;}
+		case 0:{tinker.Value[0] = 1.0 + EHSLuck;tinker.Value[1] = 0.6 + DamageLuck;tinker.Value[2] = 2.0 - AttackSpeedLuck;}
+		case 1:{tinker.Value[0] = 1.25 + EHSLuck;tinker.Value[1] = 0.7 + DamageLuck;tinker.Value[2] = 1.75 - AttackSpeedLuck;}
+		case 2:{tinker.Value[0] = 1.5 + EHSLuck;tinker.Value[1] = 0.8 + DamageLuck;tinker.Value[2] = 1.5 - AttackSpeedLuck;}
 	}
 }
 static void Tinker_SR_KillerFocus(int rarity, TinkerEnum tinker)
@@ -2091,8 +2098,8 @@ static void Tinker_SR_KillerFocus(int rarity, TinkerEnum tinker)
 
 	switch(rarity)
 	{
-		case 0:{tinker.Value[0] = 1.0 + ChargeRate;tinker.Value[1] = 0.8 + DamageLuck;}
-		case 1:{tinker.Value[0] = 1.1 + ChargeRate;tinker.Value[1] = 0.825 + DamageLuck;}
+		case 0:{tinker.Value[0] = 1.0 + ChargeRate;tinker.Value[1] = 0.7 + DamageLuck;}
+		case 1:{tinker.Value[0] = 1.1 + ChargeRate;tinker.Value[1] = 0.75 + DamageLuck;}
 		case 2:{tinker.Value[0] = 1.2 + ChargeRate;tinker.Value[1] = 0.85 + DamageLuck;}
 	}
 }
@@ -2101,19 +2108,17 @@ static void Tinker_SR_SuperCoolingChamber(int rarity, TinkerEnum tinker)
 {
 	strcopy(tinker.Name, sizeof(tinker.Name), "초냉각 약실");
 	tinker.Attrib[0] = 304;
-	tinker.Attrib[1] = 2;
-	tinker.Attrib[2] = 6;
-	tinker.Attrib[3] = 41;
+	tinker.Attrib[1] = 6;
+	tinker.Attrib[2] = 41;
 	float FullChargeDMGLuck = (0.5 * (tinker.Luck[0]));
-	float DamageLuck = (0.3 * (tinker.Luck[1]));
-	float AttackSpeedLuck = (0.25 * (tinker.Luck[2]));
-	float ChargeRate = (0.5 * (tinker.Luck[3]));
+	float AttackSpeedLuck = (0.25 * (1.0 + (-1.0*(tinker.Luck[1]))));
+	float ChargeRate = (0.35 * (1.0 + (-1.0*(tinker.Luck[2]))));
 
 	switch(rarity)
 	{
-		case 0:{tinker.Value[0] = 1.2 + FullChargeDMGLuck;tinker.Value[1] = 0.7 + DamageLuck;tinker.Value[2] = 1.5 + AttackSpeedLuck;tinker.Value[3] = 0.6 - ChargeRate;}
-		case 1:{tinker.Value[0] = 1.5 + FullChargeDMGLuck;tinker.Value[1] = 0.65 + DamageLuck;tinker.Value[2] = 1.6 + AttackSpeedLuck;tinker.Value[3] = 0.6 - ChargeRate;}
-		case 2:{tinker.Value[0] = 1.8 + FullChargeDMGLuck;tinker.Value[1] = 0.6 + DamageLuck;tinker.Value[2] = 1.7 + AttackSpeedLuck;tinker.Value[3] = 0.6 - ChargeRate;}
+		case 0:{tinker.Value[0] = 1.3 + FullChargeDMGLuck;tinker.Value[1] = 1.4 + AttackSpeedLuck;tinker.Value[2] = 0.7 - ChargeRate;}
+		case 1:{tinker.Value[0] = 1.5 + FullChargeDMGLuck;tinker.Value[1] = 1.5 + AttackSpeedLuck;tinker.Value[2] = 0.7 - ChargeRate;}
+		case 2:{tinker.Value[0] = 1.7 + FullChargeDMGLuck;tinker.Value[1] = 1.6 + AttackSpeedLuck;tinker.Value[2] = 0.7 - ChargeRate;}
 	}
 }
 
@@ -2139,14 +2144,30 @@ static void Tinker_SR_HighSpeedFeedMechanism(int rarity, TinkerEnum tinker)
 	strcopy(tinker.Name, sizeof(tinker.Name), "고속 급탄 메커니즘");
 	tinker.Attrib[0] = 2;
 	tinker.Attrib[1] = 6;
-	float DamageLuck = (0.4 * (tinker.Luck[0]));
-	float AttackSpeedLuck = (0.3 * (tinker.Luck[1]));
+	float DamageLuck = (0.325 * (1.0 + (-1.0*(tinker.Luck[0]))));
+	float AttackSpeedLuck = (0.25 * (tinker.Luck[1]));
 
 	switch(rarity)
 	{
-		case 0:{tinker.Value[0] = 0.9 - DamageLuck;tinker.Value[1] = 1.0 - AttackSpeedLuck;}
-		case 1:{tinker.Value[0] = 0.95 - DamageLuck;tinker.Value[1] = 0.9 - AttackSpeedLuck;}
+		case 0:{tinker.Value[0] = 0.9 - DamageLuck;tinker.Value[1] = 0.9 - AttackSpeedLuck;}
+		case 1:{tinker.Value[0] = 0.95 - DamageLuck;tinker.Value[1] = 0.8 - AttackSpeedLuck;}
 		case 2:{tinker.Value[0] = 1.0 - DamageLuck;tinker.Value[1] = 0.75 - AttackSpeedLuck;}
+	}
+}
+
+static void Tinker_SR_HollowPointBullets(int rarity, TinkerEnum tinker)
+{
+	strcopy(tinker.Name, sizeof(tinker.Name), "할로우 포인트 탄환");
+	tinker.Attrib[0] = 2;
+	tinker.Attrib[1] = 390;
+	float DamageLuck = (0.25 * (tinker.Luck[0]));
+	float HeadDMGLuck = (0.3 * (tinker.Luck[1]));
+
+	switch(rarity)
+	{
+		case 0:{tinker.Value[0] = 0.75 + DamageLuck;tinker.Value[1] = 1.35 + HeadDMGLuck;}
+		case 1:{tinker.Value[0] = 0.7 + DamageLuck;tinker.Value[1] = 1.5 + HeadDMGLuck;}
+		case 2:{tinker.Value[0] = 0.675 + DamageLuck;tinker.Value[1] = 1.672 + HeadDMGLuck;}
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_blacksmith.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_blacksmith.sp
@@ -533,6 +533,26 @@ void Blacksmith_BuildingUsed_Internal(int weapon ,int entity, int client, int ow
 					default:Tinker_MS_Sharpness(tinker.Rarity, tinker);
 				}
 			}
+			default:
+			{
+				if(Attributes_Get(weapon, Attrib_IsSniperRifle, 0.0) != 0.0)
+				{
+					BlockNormal = true;
+					switch(GetURandomInt() % 4)
+					{
+						case 0:
+							Tinker_SR_ExplosiveHeadshot(tinker.Rarity, tinker);
+						case 1:
+							Tinker_SR_KillerFocus(tinker.Rarity, tinker);
+						case 2:
+							Tinker_SR_SuperCoolingChamber(tinker.Rarity, tinker);
+						case 3:
+							Tinker_SR_DepletedUranium(tinker.Rarity, tinker);
+						case 4:
+							Tinker_SR_HighSpeedFeedMechanism(tinker.Rarity, tinker);
+					}
+				}
+			}
 		}
 		if(Attributes_Get(client, Attrib_DisallowTinker, 0.0) != 0.0)
 		{
@@ -964,6 +984,8 @@ void Blacksmith_PrintAttribValue(int client, int attrib, float value, float luck
 		{
 			if(CustomMode==1)
 				Format(buffer, sizeof(buffer), "%s 휩쓸기 충전속도", buffer);
+			else
+				Format(buffer, sizeof(buffer), "%s 충전 속도", buffer);
 		}
 		
 		case 45:
@@ -1077,7 +1099,12 @@ void Blacksmith_PrintAttribValue(int client, int attrib, float value, float luck
 		
 		case 4019:
 			Format(buffer, sizeof(buffer), "%s 최대 마나", buffer);
-
+			
+		case Attrib_ExplosiveHeadshot:
+			Format(buffer, sizeof(buffer), "%s 폭발성 헤드샷 피해량", buffer);
+			
+		case 305:
+			Format(buffer, sizeof(buffer), "%s 완전 충전 시 피해량", buffer);
 	}
 	
 	CPrintToChat(client, "%s {yellow}(%d％)", buffer, RoundToCeil(luck * 100.0));
@@ -2034,6 +2061,92 @@ static void Tinker_MS_CurseofGlassy(int rarity, TinkerEnum tinker)
 		case 2:{tinker.Value[0] = 1.4 + DamageLuck;tinker.Value[1] = 1.35 + SweepingLuck;tinker.Value[2] = 1.1 + RangedDmgVulLuck;tinker.Value[3] = 1.1 + MeleeDmgVulLuck;}
 		case 3:{tinker.Value[0] = 1.5 + DamageLuck;tinker.Value[1] = 1.4 + SweepingLuck;tinker.Value[2] = 1.25 + RangedDmgVulLuck;tinker.Value[3] = 1.25 + MeleeDmgVulLuck;}
 		case 4:{tinker.Value[0] = 1.6 + DamageLuck;tinker.Value[1] = 1.45 + SweepingLuck;tinker.Value[2] = 1.35 + RangedDmgVulLuck;tinker.Value[3] = 1.35 + MeleeDmgVulLuck;}
+	}
+}
+
+static void Tinker_SR_ExplosiveHeadshot(int rarity, TinkerEnum tinker)
+{
+	strcopy(tinker.Name, sizeof(tinker.Name), "폭발성 헤드샷");
+	tinker.Attrib[0] = Attrib_ExplosiveHeadshot;
+	tinker.Attrib[1] = 2;
+	tinker.Attrib[2] = 6;
+	float EHSLuck = (0.25 * (tinker.Luck[0]));
+	float DamageLuck = (0.1 * (tinker.Luck[1]));
+	float AttackSpeedLuck = (0.1 * (tinker.Luck[2]));
+
+	switch(rarity)
+	{
+		case 0:{tinker.Value[0] = 1.0 + EHSLuck;tinker.Value[1] = 0.6 + DamageLuck;tinker.Value[2] = 2.5 - AttackSpeedLuck;}
+		case 1:{tinker.Value[0] = 1.25 + EHSLuck;tinker.Value[1] = 0.7 + DamageLuck;tinker.Value[2] = 2.0 - AttackSpeedLuck;}
+		case 2:{tinker.Value[0] = 1.5 + EHSLuck;tinker.Value[1] = 0.8 + DamageLuck;tinker.Value[2] = 1.85 - AttackSpeedLuck;}
+	}
+}
+static void Tinker_SR_KillerFocus(int rarity, TinkerEnum tinker)
+{
+	strcopy(tinker.Name, sizeof(tinker.Name), "살인적인 집중");
+	tinker.Attrib[0] = 41;
+	tinker.Attrib[1] = 2;
+	float ChargeRate = (0.2 * (tinker.Luck[0]));
+	float DamageLuck = (0.2 * (tinker.Luck[1]));
+
+	switch(rarity)
+	{
+		case 0:{tinker.Value[0] = 1.0 + ChargeRate;tinker.Value[1] = 0.8 + DamageLuck;}
+		case 1:{tinker.Value[0] = 1.1 + ChargeRate;tinker.Value[1] = 0.825 + DamageLuck;}
+		case 2:{tinker.Value[0] = 1.2 + ChargeRate;tinker.Value[1] = 0.85 + DamageLuck;}
+	}
+}
+
+static void Tinker_SR_SuperCoolingChamber(int rarity, TinkerEnum tinker)
+{
+	strcopy(tinker.Name, sizeof(tinker.Name), "초냉각 약실");
+	tinker.Attrib[0] = 304;
+	tinker.Attrib[1] = 2;
+	tinker.Attrib[2] = 6;
+	tinker.Attrib[3] = 41;
+	float FullChargeDMGLuck = (0.5 * (tinker.Luck[0]));
+	float DamageLuck = (0.3 * (tinker.Luck[1]));
+	float AttackSpeedLuck = (0.25 * (tinker.Luck[2]));
+	float ChargeRate = (0.5 * (tinker.Luck[3]));
+
+	switch(rarity)
+	{
+		case 0:{tinker.Value[0] = 1.2 + FullChargeDMGLuck;tinker.Value[1] = 0.7 + DamageLuck;tinker.Value[2] = 1.5 + AttackSpeedLuck;tinker.Value[3] = 0.6 - ChargeRate;}
+		case 1:{tinker.Value[0] = 1.5 + FullChargeDMGLuck;tinker.Value[1] = 0.65 + DamageLuck;tinker.Value[2] = 1.6 + AttackSpeedLuck;tinker.Value[3] = 0.6 - ChargeRate;}
+		case 2:{tinker.Value[0] = 1.8 + FullChargeDMGLuck;tinker.Value[1] = 0.6 + DamageLuck;tinker.Value[2] = 1.7 + AttackSpeedLuck;tinker.Value[3] = 0.6 - ChargeRate;}
+	}
+}
+
+static void Tinker_SR_DepletedUranium(int rarity, TinkerEnum tinker)
+{
+	strcopy(tinker.Name, sizeof(tinker.Name), "U-238");
+	tinker.Attrib[0] = 2;
+	tinker.Attrib[1] = 6;
+	tinker.Attrib[2] = 41;
+	float DamageLuck = (0.3 * (tinker.Luck[0]));
+	float AttackSpeedLuck = (0.25 * (tinker.Luck[1]));
+
+	switch(rarity)
+	{
+		case 0:{tinker.Value[0] = 1.25 + DamageLuck;tinker.Value[1] = 1.3 - AttackSpeedLuck;tinker.Value[2] = 0.0;}
+		case 1:{tinker.Value[0] = 1.3 + DamageLuck;tinker.Value[1] = 1.25 - AttackSpeedLuck;tinker.Value[2] = 0.0;}
+		case 2:{tinker.Value[0] = 1.4 + DamageLuck;tinker.Value[1] = 1.15 - AttackSpeedLuck;tinker.Value[2] = 0.0;}
+	}
+}
+
+static void Tinker_SR_HighSpeedFeedMechanism(int rarity, TinkerEnum tinker)
+{
+	strcopy(tinker.Name, sizeof(tinker.Name), "고속 급탄 메커니즘");
+	tinker.Attrib[0] = 2;
+	tinker.Attrib[1] = 6;
+	float DamageLuck = (0.4 * (tinker.Luck[0]));
+	float AttackSpeedLuck = (0.3 * (tinker.Luck[1]));
+
+	switch(rarity)
+	{
+		case 0:{tinker.Value[0] = 0.9 - DamageLuck;tinker.Value[1] = 1.0 - AttackSpeedLuck;}
+		case 1:{tinker.Value[0] = 0.95 - DamageLuck;tinker.Value[1] = 0.9 - AttackSpeedLuck;}
+		case 2:{tinker.Value[0] = 1.0 - DamageLuck;tinker.Value[1] = 0.75 - AttackSpeedLuck;}
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_kritzkrieg.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_kritzkrieg.sp
@@ -20,7 +20,7 @@ static void OnKritzkriegDeployed(Event event, const char[] name, bool dontBroadc
 		return;
 
 	int medigun;
-	bool Continune = false;
+	bool Continune = false, Adaptive = false;
 	int ie;
 	int entity;
 	while(TF2_GetItem(client, entity, ie))
@@ -29,6 +29,11 @@ static void OnKritzkriegDeployed(Event event, const char[] name, bool dontBroadc
 		{
 			medigun = entity;
 			Continune = true;
+		}
+		if(i_CustomWeaponEquipLogic[entity] == WEAPON_ADAPTIVE_MEDIGUN)
+		{
+			medigun = entity;
+			Adaptive = true;
 		}
 	}
 	GiveMedigunBuffUber(medigun, client, client);
@@ -43,6 +48,49 @@ static void OnKritzkriegDeployed(Event event, const char[] name, bool dontBroadc
 			EmitSoundToClient(target, "player/invuln_on_vaccinator.wav", target, SNDCHAN_AUTO, 65, _, 0.6);
 
 		EmitSoundToAll("player/invuln_on_vaccinator.wav", client, SNDCHAN_AUTO, 65, _, 0.6);
+		
+		if(Adaptive)
+		{
+			float Healing_Value = Attributes_GetOnWeapon(client, medigun, 8, true);
+			if(IsValidClient(target) && IsPlayerAlive(target))
+			{
+				if(dieingstate[target] > 0)
+					dieingstate[target] = 1;
+				else
+					HealEntityGlobal(client, target, (float(SDKCall_GetMaxHealth(target))*0.2)+Healing_Value, 1.25*Attributes_Get(medigun, 4002, 1.0), 1.0, HEAL_ABSOLUTE);
+			}
+			if(dieingstate[client] > 0)
+				dieingstate[client] = 1;
+			else
+				HealEntityGlobal(client, client, (float(SDKCall_GetMaxHealth(client))*0.2)+Healing_Value, 1.25*Attributes_Get(medigun, 4002, 1.0), 1.0, HEAL_SELFHEAL);
+			float position[3]; WorldSpaceCenter(client, position);
+			for(int entitycount; entitycount<i_MaxcountNpcTotal; entitycount++)
+			{
+				int npc = EntRefToEntIndexFast(i_ObjectsNpcsTotal[entitycount]);
+				if(IsValidEntity(npc) && GetTeam(npc) == TFTeam_Red)
+				{
+					float position2[3];
+					WorldSpaceCenter(npc, position2);
+					if(GetVectorDistance(position, position2,true)<250000.0)
+						ApplyStatusEffect(client, npc, "UBERCHARGED", 3.0);
+				}
+			}
+			for(int AoE=1; AoE<=MaxClients; AoE++)
+			{
+				if(IsValidClient(AoE) && IsPlayerAlive(AoE) && TeutonType[AoE] == TEUTON_NONE)
+				{
+					float position2[3];
+					WorldSpaceCenter(AoE, position2);
+					if(GetVectorDistance(position, position2,true)<250000.0)
+					{
+						TF2_AddCondition(AoE, TFCond_UberBulletResist, 3.0);
+						TF2_AddCondition(AoE, TFCond_UberBlastResist, 3.0);
+						TF2_AddCondition(AoE, TFCond_UberFireResist, 3.0);
+						ApplyStatusEffect(client, AoE, "UBERCHARGED", 3.0);
+					}
+				}
+			}
+		}
 		return;
 	}
 	if(IsValidEntity(target) && IsValidClient(target))
@@ -51,9 +99,9 @@ static void OnKritzkriegDeployed(Event event, const char[] name, bool dontBroadc
 	EmitSoundToAll("player/mannpower_invulnerable.wav", client, SNDCHAN_AUTO, 65, _, 0.6);
 
 	if(IsValidClient(target) && IsPlayerAlive(target)) 
-	{
 		GiveArmorViaPercentage(target, 0.5, 1.0,_,_,client);
-	}
+	else if(IsValidEntity(target) && !b_NpcHasDied[target])
+		GrantEntityArmor(target, false, 0.5, 0.7, 0);
 	GiveArmorViaPercentage(client, 0.5, 1.0,_,_,client);
 	if(RaidbossIgnoreBuildingsLogic(1))
 	{
@@ -61,9 +109,6 @@ static void OnKritzkriegDeployed(Event event, const char[] name, bool dontBroadc
 		flChargeLevel *= 0.65;
 		SetEntPropFloat(medigun, Prop_Send, "m_flChargeLevel", flChargeLevel);
 	}
-
-
-
 }
 static int GetHealingTarget(int client)
 {
@@ -120,4 +165,20 @@ void Kritzkrieg_Magical(int client, float Scale, bool apply)
 			}
 		}
 	}
+}
+
+int Adaptive_FastRevive(int client)
+{
+	int speed = 6;
+	if(i_CurrentEquippedPerk[client] & 1)
+		speed = 12;
+	
+	if(HasSpecificBuff(client, "Dimensional Turbulence"))
+		speed *= 2;
+	
+	int activeWeapon = GetEntPropEnt(client, Prop_Send, "m_hActiveWeapon");
+	if(IsValidEntity(activeWeapon))
+		speed = RoundToNearest(float(speed) * Attributes_Get(activeWeapon, Attrib_ReviveSpeedBonus, 1.0));
+	Rogue_ReviveSpeed(speed);
+	return speed;
 }

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_slug_rifle.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_slug_rifle.sp
@@ -2,9 +2,19 @@
 #pragma newdecls required
 
 float Uranium_TimeTillBigHit[MAXPLAYERS][MAXENTITIES];
+
+static bool SniperRifle_HeadShot[MAXPLAYERS];
+static int SniperRifle_Ignore[MAXPLAYERS];
+static float SniperRifle_ExplodDMG[MAXPLAYERS];
+static float SniperRifle_Charge[MAXPLAYERS];
+
 void Uranium_MapStart()
 {
 	Zero2(Uranium_TimeTillBigHit);
+	Zero(SniperRifle_HeadShot);
+	Zero(SniperRifle_Ignore);
+	ZeroFloat(SniperRifle_ExplodDMG);
+	ZeroFloat(SniperRifle_Charge);
 }
 
 void EnemyResetUranium(int enemy)
@@ -21,6 +31,41 @@ public void Weapon_Anti_Material_Rifle(int client, int weapon, bool crit, int sl
 	Client_Shake(client, 0, 50.0, 25.0, 1.5);
 }
 
+public void Weapon_SniperRifle_M1(int client, int weapon, bool crit, int slot)
+{
+	
+	bool CheckHitBox;
+	if(Attributes_Get(weapon, Attrib_ExplosiveHeadshot, 1.0) > 1.0)
+	{
+		CheckHitBox=true;
+		float charge=GetEntPropFloat(weapon, Prop_Send, "m_flChargedDamage");
+		if(charge<150.0 || !TF2_IsPlayerInCondition(client, TFCond_Zoomed))
+			EmitSoundToAll("weapons/sniper_shoot.wav", client, SNDCHAN_STATIC, 80, _, 1.0);
+	}
+	if(Attributes_Get(weapon, 390, 0.0) != 1.0)
+		CheckHitBox=true;
+	if(CheckHitBox)
+	{
+		static float vAngles[3], vOrigin[3];
+		GetClientEyePosition(client, vOrigin);
+		GetClientEyeAngles(client, vAngles);
+		Handle trace = TR_TraceRayFilterEx(vOrigin, vAngles, MASK_SHOT, RayType_Infinite, BulletAndMeleeTrace, client);
+		if(TR_GetFraction(trace) < 1.0)
+		{
+			int target = TR_GetEntityIndex(trace);
+			if(target > 0 && !b_CannotBeHeadshot[target])
+			{
+				if(TR_GetHitGroup(trace) == HITGROUP_HEAD)
+				{
+					SniperRifle_Ignore[client]=EntIndexToEntRef(target);
+					SniperRifle_HeadShot[client]=true;
+				}
+			}
+		}
+		delete trace;
+	}
+
+}
 
 public void Weapon_Anti_Material_Rifle_Deploy(int client, int weapon)
 {
@@ -45,5 +90,32 @@ void WeaponUranium_OnTakeDamage(int attacker,int victim, float &damage, float da
 			EmitSoundToClient(attacker, "weapons/physcannon/energy_sing_explosion2.wav", attacker, SNDCHAN_STATIC, 80, _, 1.0);
 			TE_Particle("mvm_soldier_shockwave", damagePosition, NULL_VECTOR, {0.0,0.0,0.0}, -1, _, _, _, _, _, _, _, _, _, 0.0, .clientspec = attacker);
 		}
+	}
+}
+
+public void SniperRifle_NPCTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int zr_custom_damage)
+{
+	if(!CheckInHud() && SniperRifle_HeadShot[attacker])
+	{
+		float attrib = Attributes_Get(weapon, Attrib_ExplosiveHeadshot, 1.0);
+		if(attrib > 1.0)
+		{
+			SpawnSmallExplosion(damagePosition);
+			SniperRifle_ExplodDMG[attacker] = damage * attrib;
+			Explode_Logic_Custom(0.0, attacker, attacker, -1, damagePosition, _, _, _, true, _, false, _, Func_ExplosiveHeadshot);
+		}
+		attrib = Attributes_Get(weapon, 390, 1.0);
+		if(attrib != 1.0)
+			damage*=attrib;
+		SniperRifle_HeadShot[attacker]=false;
+	}
+}
+static void Func_ExplosiveHeadshot(int entity, int victim, float damage, int weapon)
+{
+	if(IsValidEntity(entity) && IsValidEntity(victim) && GetTeam(entity) != GetTeam(victim))
+	{
+		int Ignore = EntRefToEntIndex(SniperRifle_Ignore[entity]);
+		if(Ignore != victim)
+			SDKHooks_TakeDamage(victim, entity, entity, SniperRifle_ExplodDMG[entity], DMG_BLAST|DMG_PREVENT_PHYSICS_FORCE);
 	}
 }

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_slug_rifle.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_slug_rifle.sp
@@ -29,11 +29,11 @@ public void Weapon_Anti_Material_Rifle(int client, int weapon, bool crit, int sl
 {
 	EmitSoundToAll("npc/vort/attack_shoot.wav", client, SNDCHAN_STATIC, 80, _, 1.0);
 	Client_Shake(client, 0, 50.0, 25.0, 1.5);
+	Weapon_SniperRifle_M1(client, weapon, crit, slot);
 }
 
 public void Weapon_SniperRifle_M1(int client, int weapon, bool crit, int slot)
 {
-	
 	bool CheckHitBox;
 	if(Attributes_Get(weapon, Attrib_ExplosiveHeadshot, 1.0) > 1.0)
 	{
@@ -67,18 +67,6 @@ public void Weapon_SniperRifle_M1(int client, int weapon, bool crit, int slot)
 
 }
 
-public void Weapon_Anti_Material_Rifle_Deploy(int client, int weapon)
-{
-	if (i_CustomWeaponEquipLogic[weapon] == WEAPON_URANIUM_RIFLE)	 // 125
-	{
-	//	if(Items_HasNamedItem(client, "Head Equipped Blue Goggles"))
-		{
-			Attributes_Set(weapon, 304, 1.1);
-		}
-	}
-}
-
-
 void WeaponUranium_OnTakeDamage(int attacker,int victim, float &damage, float damagePosition[3])
 {
 	if(Uranium_TimeTillBigHit[attacker][victim] < GetGameTime())
@@ -95,19 +83,32 @@ void WeaponUranium_OnTakeDamage(int attacker,int victim, float &damage, float da
 
 public void SniperRifle_NPCTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int zr_custom_damage)
 {
-	if(!CheckInHud() && SniperRifle_HeadShot[attacker])
+	if(!CheckInHud())
 	{
-		float attrib = Attributes_Get(weapon, Attrib_ExplosiveHeadshot, 1.0);
-		if(attrib > 1.0)
+		if(SniperRifle_HeadShot[attacker])
 		{
-			SpawnSmallExplosion(damagePosition);
-			SniperRifle_ExplodDMG[attacker] = damage * attrib;
-			Explode_Logic_Custom(0.0, attacker, attacker, -1, damagePosition, _, _, _, true, _, false, _, Func_ExplosiveHeadshot);
+			float attrib = Attributes_Get(weapon, Attrib_ExplosiveHeadshot, 1.0);
+			if(attrib > 1.0)
+			{
+				SpawnSmallExplosion(damagePosition);
+				SniperRifle_ExplodDMG[attacker] = damage * attrib;
+				Explode_Logic_Custom(0.0, attacker, attacker, -1, damagePosition, _, _, _, true, _, false, _, Func_ExplosiveHeadshot);
+			}
+			attrib = Attributes_Get(weapon, 390, 1.0);
+			if(attrib != 1.0)
+				damage*=attrib;
+			SniperRifle_HeadShot[attacker]=false;
 		}
-		attrib = Attributes_Get(weapon, 390, 1.0);
-		if(attrib != 1.0)
-			damage*=attrib;
-		SniperRifle_HeadShot[attacker]=false;
+		if(i_CustomWeaponEquipLogic[weapon] == WEAPON_URANIUM_RIFLE && Uranium_TimeTillBigHit[attacker][victim] < GetGameTime())
+		{
+			damage *= 2.2;
+			if(!CheckInHud())
+			{
+				Uranium_TimeTillBigHit[attacker][victim] = GetGameTime() + 40.0;
+				EmitSoundToClient(attacker, "weapons/physcannon/energy_sing_explosion2.wav", attacker, SNDCHAN_STATIC, 80, _, 1.0);
+				TE_Particle("mvm_soldier_shockwave", damagePosition, NULL_VECTOR, {0.0,0.0,0.0}, -1, _, _, _, _, _, _, _, _, _, 0.0, .clientspec = attacker);
+			}
+		}
 	}
 }
 static void Func_ExplosiveHeadshot(int entity, int victim, float damage, int weapon)

--- a/addons/sourcemod/scripting/zombie_riot/npc/baka/npc_cybergrind_gm.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/baka/npc_cybergrind_gm.sp
@@ -185,19 +185,15 @@ methodmap CyberGrindGM < CClotBody
 		{
 			func_NPCDeath[npc.index] = INVALID_FUNCTION;
 			func_NPCOnTakeDamage[npc.index] = INVALID_FUNCTION;
-			func_NPCThink[npc.index] = INVALID_FUNCTION;
+			func_NPCThink[npc.index] = CyberGrindGM_OverrideMusic;
 			
 			char buffers[3][64];
 			ExplodeString(data, ";", buffers, sizeof(buffers), sizeof(buffers[]));
 			ReplaceString(buffers[0], 64, "set_wavelimit", "");
 			
-			WaveStart_SubWaveStart(GetGameTime() + StringToFloat(buffers[0]));
-			
-			b_NpcForcepowerupspawn[npc.index] = 0;
-			i_RaidGrantExtra[npc.index] = 0;
-			b_DissapearOnDeath[npc.index] = true;
-			b_DoGibThisNpc[npc.index] = true;
-			SmiteNpcToDeath(npc.index);
+			npc.m_flAddRiadTime = StringToFloat(buffers[0]);
+			npc.m_iOverlordComboAttack = 101;
+			npc.m_flCoolDown = GetGameTime() + 1.0;
 			return npc;
 		}
 		else if(!StrContains(data, "set_raidlimit"))
@@ -723,6 +719,7 @@ static void CyberGrindGM_OverrideMusic(int iNPC)
 				Music_SetRaidMusic(music);
 			}
 			case 100: RaidModeTime += npc.m_flAddRiadTime;
+			case 101: WaveStart_SubWaveStart(GetGameTime() + npc.m_flAddRiadTime);
 		}
 		b_NpcForcepowerupspawn[npc.index] = 0;
 		i_RaidGrantExtra[npc.index] = 0;

--- a/addons/sourcemod/scripting/zombie_riot/npc/baka/npc_invisible_trigger_man.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/baka/npc_invisible_trigger_man.sp
@@ -235,6 +235,17 @@ methodmap Invisible_TRIGGER_Man < CClotBody
 			b_ThisEntityIgnoredByOtherNpcsAggro[npc.index] = true;
 			fVerify=true;
 		}
+		if(!StrContains(data, "fast_building_cooldown"))
+		{
+			npc.i_NPCStats=9;
+			
+			SetTeam(npc.index, TFTeam_Red);
+			AddNpcToAliveList(npc.index, 1);
+			Is_a_Medic[npc.index] = true;
+			npc.m_bStaticNPC = true;
+			b_ThisEntityIgnoredByOtherNpcsAggro[npc.index] = true;
+			fVerify=true;
+		}
 
 		func_NPCDeath[npc.index] = view_as<Function>(Invisible_TRIGGER_Man_NPCDeath);
 		func_NPCOnTakeDamage[npc.index] = view_as<Function>(Invisible_TRIGGER_Man_OnTakeDamage);
@@ -297,6 +308,18 @@ static void Cybergrind_EX_Hard_Mode_ClotThink(int iNPC)
 	if(npc.m_flNextThinkTime > gameTime)
 		return;
 	npc.m_flNextThinkTime = gameTime + 0.1;
+	
+	if(!Waves_Started() && Waves_InSetup())
+	{
+		for(int client = 1; client <= MaxClients; client++)
+		{
+			if(IsValidClient(client))
+			{
+				if(TeutonType[client] == TEUTON_NONE && IsPlayerAlive(client))
+					ApplyStatusEffect(client, client, "Depot Transfer", 1.0);
+			}
+		}
+	}
 	
 	if(npc.m_bIsToggle)
 		return;
@@ -974,6 +997,7 @@ static void Invisible_TRIGGER_Man_ClotThink(int iNPC)
 		{
 			if(Waves_Started() && !Waves_InSetup())
 			{
+				WaveStart_SubWaveStart(GetGameTime() + 600.0);
 				NPCStats_RemoveAllDebuffs(npc.index, 1.0);
 				if(!npc.m_iTargetAlly || npc.m_flGetClosestTargetTime < gameTime)
 				{
@@ -1112,7 +1136,36 @@ static void Invisible_TRIGGER_Man_ClotThink(int iNPC)
 			b_DissapearOnDeath[npc.index] = true;
 			b_DoGibThisNpc[npc.index] = true;
 			SmiteNpcToDeath(npc.index);
-		}
+		} 
+		case 9:
+		{
+			if(Waves_Started() && !Waves_InSetup())
+			{
+				if(!npc.m_flCoolDown)
+					npc.m_flCoolDown = gameTime + 20.0;
+			}
+			else
+			{
+				npc.m_flCoolDown=0.0;
+				for(int client = 1; client <= MaxClients; client++)
+				{
+					if(IsValidClient(client))
+					{
+						if(TeutonType[client] == TEUTON_NONE && IsPlayerAlive(client))
+							ApplyStatusEffect(client, client, "Depot Transfer", 1.0);
+					}
+				}
+			}
+
+			if(npc.m_flCoolDown && npc.m_flCoolDown < gameTime)
+			{
+				b_NpcForcepowerupspawn[npc.index] = 0;
+				i_RaidGrantExtra[npc.index] = 0;
+				b_DissapearOnDeath[npc.index] = true;
+				b_DoGibThisNpc[npc.index] = true;
+				SmiteNpcToDeath(npc.index);
+			}
+		} 
 	}
 	
 	if(npc.m_flNextThinkTime > gameTime)

--- a/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/npc_the_messenger.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/npc_the_messenger.sp
@@ -437,11 +437,6 @@ methodmap TheMessenger < CClotBody
 	}
 }
 
-static void NPCTalkMessage(int iNPC, const char[] message)
-{
-	PrintNPCMessageWithPrefixes(iNPC, "lightblue", message);
-}
-
 void TheMessenger_NPCTalkMessage(int iNPC, const char[] message, any ...)
 {
 	char buffer[255];

--- a/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/npc_the_messenger.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/npc_the_messenger.sp
@@ -441,7 +441,7 @@ void TheMessenger_NPCTalkMessage(int iNPC, const char[] message, any ...)
 {
 	char buffer[255];
 	VFormat(buffer, sizeof(buffer), message, 3);
-	PrintNPCMessageWithPrefixes(iNPC, "lightblue", message);
+	PrintNPCMessageWithPrefixes(iNPC, "lightblue", buffer);
 }
 
 public void TheMessenger_ClotThink(int iNPC)

--- a/addons/sourcemod/scripting/zombie_riot/store.sp
+++ b/addons/sourcemod/scripting/zombie_riot/store.sp
@@ -6914,7 +6914,6 @@ int Store_GiveItem(int client, int index, bool &use=false, bool &found=false, bo
 		Yakuza_Enable(client, entity);
 		Enable_SkadiWeapon(client, entity);
 		Enable_Hunting_Rifle(client, entity);
-		Weapon_Anti_Material_Rifle_Deploy(client, entity);
 		Walter_Enable(client, entity);
 		Enable_CastleBreakerWeapon(client, entity);
 		Purnell_Enable(client, entity);

--- a/addons/sourcemod/scripting/zombie_riot/zr_core.sp
+++ b/addons/sourcemod/scripting/zombie_riot/zr_core.sp
@@ -350,6 +350,7 @@ enum
 	WEAPON_IS_STICKYBOMB = 1005,
 	WEAPON_IS_AUTOSHOTGUN = 1006,
 	WEAPON_KIT_SURVIVALIST = 1007,
+	WEAPON_ADAPTIVE_MEDIGUN = 1008,
 };
 
 enum
@@ -763,6 +764,7 @@ char s_MissionClient[64]; // Who hired us for the current job
 #include "custom/addons/weapon_majorsteam_launcher.sp"
 #include "custom/addons/weapon_mostima.sp"
 #include "custom/addons/weapon_minecraft_sword.sp"
+#include "custom/addons/weapon_mini_semi_gun.sp"
 #include "custom/kit_soldine.sp"
 #include "custom/weapon_kritzkrieg.sp"
 #include "custom/wand/weapon_bubble_wand.sp"

--- a/addons/sourcemod/translations/zombieriot.phrases.foolishservers.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.foolishservers.txt
@@ -761,6 +761,12 @@
 		"ko"		"대구경 저격소총"
 	}
 	
+	"Custom Sniper Rifle Desc"
+	{
+		"en"		"Heavy Caliber Sniper Rifle"
+		"ko"		"대구경 저격소총"
+	}
+	
 	//무기 설명
 	"Chaos Infected Launcher desc"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.foolishservers.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.foolishservers.txt
@@ -537,6 +537,16 @@
 		"en"	"Support weapons are discarded upon expiration"
 		"ko"	"만료시, 지원무기가 폐기됨"
 	}
+	"Inspire"
+	{
+		"en"	"Inspire"
+		"ko"	"인스파이어"
+	}
+	"Inspire Desc"
+	{
+		"en"	"Revive downed allies faster while Uber is active."
+		"ko"	"우버 지속 중 쓰러진 아군을 더 빠르게 소생시킴."
+	}
 	
 	//무기 이름
 	"Chaos Infected Launcher"
@@ -765,6 +775,17 @@
 	{
 		"en"		"Heavy Caliber Sniper Rifle"
 		"ko"		"대구경 저격소총"
+	}
+	
+	"Custom Mini Semi Gun: Overheating FeedBack"
+	{
+		"en"		"Overheating FeedBack"
+		"ko"		"괴열 피드백"
+	}
+	"Custom Mini Semi Gun: Bullet Storm"
+	{
+		"en"		"Bullet Storm"
+		"ko"		"납탄 폭풍"
 	}
 	
 	//무기 설명
@@ -1042,6 +1063,37 @@
 	{
 		"en"		"Forbidden weapon known to mankind. \nBuild up charges by hitting enemies with projectiles \nM2 to summon your ally npcs \n Enhancing this weapon in different route will summon different set of npcs!"
 		"ko"		"인류에게 대대로 전해진 금지된 무기입니다.\n투사체를 적중해 에너지를 쌓고 M2를 눌러 소환수를 스폰.\n무기 강화 루트에 따라 다른 그룹의 npc들이 등장"
+	}
+	
+	"Custom Mini Semi Gun: Overheating FeedBack Desc"
+	{
+		"en"		"The longer you hold down fire, the more damage and tighter spread your weapon deals"
+		"ko"		"공격 버튼을 오래 누르고 있을수록, 이 무기의 피해량및 집탄율 증가"
+	}
+	"Custom Mini Semi Gun: Overheating FeedBack - Overclocking MAX"
+	{
+		"en"		"[Overclock MOD]\nMAX Overheat"
+		"ko"		"[과부하 모드]\n최대 과열 도달"
+	}
+	"Custom Mini Semi Gun: Overheating FeedBack - Overclocking Charge"
+	{
+		"en"		"[Overclock MOD]\nHeating up:"
+		"ko"		"[과부하 모드]\n예열중:"
+	}
+	"Custom Mini Semi Gun: Overheating FeedBack - MAX"
+	{
+		"en"		"MAX Overheat"
+		"ko"		"최대 과열 도달"
+	}
+	"Custom Mini Semi Gun: Overheating FeedBack - Charge"
+	{
+		"en"		"Heating up:"
+		"ko"		"예열 중:"
+	}
+	"Custom Mini Semi Gun: Bullet Storm Desc"
+	{
+		"en"		"+300％ bullets per shot\ncannot move while firing, consumes 4 ammo per shot."
+		"ko"		"발사되는 탄환수 +300％증가\n사격중 이동 불가, 발사당 4발의 탄약을 소모."
 	}
 	
 	//추가 장비 이름

--- a/addons/sourcemod/translations/zombieriot.phrases.foolishservers.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.foolishservers.txt
@@ -755,6 +755,12 @@
 		"ko"		"차원 왜곡: 연구소"
 	}
 	
+	"Sniper Rifle - pap1"
+	{
+		"en"		"Heavy Caliber Sniper Rifle"
+		"ko"		"대구경 저격소총"
+	}
+	
 	//무기 설명
 	"Chaos Infected Launcher desc"
 	{


### PR DESCRIPTION
# 무기
## 스나이퍼 라이플:
\+ 전용 모루 추가
\- 세부 루트는 아직 개발중입니다

## 메디건:
\+앉아서 +R로 유형 변경을 R키로 유형 변경가능하게 수정

## 메디건 - 적응형 메디건:
\= R키로 피해저항 유형 변경 가능, 앉아서 공격,치유 유형 변경 가능
\+ 우버 사용 시, 주변 아군에게 3초 우버 적용
\+ 우버 발동 즉시 치료 대상을 소생 시킵니다
\+ 우버 발동 즉시 치료 대상및 자신의 체력을 최대 체력의 20％ 만큼 회복합니다
\+ 자신이 쓰러진 상태에서 우버 발동 시, 사용자는 즉시 소생 가능 상태로 만듭니다
\+ 우버 지속시간 동안 인스파이어 효과 적용
= 인스파이어: 메다 건의 소생 페널티 삭제, 매디건 미사용 소생 속도 2배 증가

## 데글:
\+ 무기 클래스 샷건 -> 리볼버로 변경됨
\+ 무기 뷰모델 스카웃 -> 엔지니어로 변경됨

## 기관단총 - 미니 세미 건
\+ 팩펀 가격 12000 -> 10000 인하
\+ 루트 두개 추가됨
\+ 괴열 피드백:
├ + 피해량 증가
├ + 공격 버튼을 오래 누르고 있을수록, 이 무기의 피해량및 집탄율 증가
└ - 팩펀 가격 2000
\+ 납탄 폭풍:
├ + 발사되는 탄환수 +300％증가
├ - 사격중 이동 불가
├ - 발사당 4발의 탄약을 소모
└ - 팩펀 가격 2000

# ETC
## 지옥에서 보자:
\+ 쿨다운 60초 -> 10초

## 보요의 신비로운 맥주:
\= 아머 박살이 원소 피해를 회복시켜주던 문제 수정

## 사이버 그라인드:
\+ 준비 시간동안 구조물 쿨다운이 0.5초로 고정됨
\- 누락된 10웨이브 네말 재추가
\= 누락된 39 웨이브 심연의 전령 재추가 (6개의 만파워 먹은 심연의 전령을 더이상 볼수 없음)