### PR TITLE
패치내용

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/fast_zs.cfg
+++ b/addons/sourcemod/configs/zombie_riot/fast_zs.cfg
@@ -84,8 +84,8 @@
 		"1.0"
 		{
 			"cash"	"0"
-			"count"	 "1"
-			"health"	"15000"
+			"count"	 "0"
+			"health"	"10000"
 			"is_boss"	"1"
 			"plugin"	"npc_random_zombie"
 		}
@@ -197,7 +197,7 @@
 		"1.0"
 		{
 			"cash"	"0"
-			"count"		"1"
+			"count"		"0"
 			"health"	"15000"
 			"is_boss"	"1"
 			"plugin"	"npc_random_zombie"
@@ -284,7 +284,7 @@
 		"2.0"
 		{
 			"cash"	"0"
-			"count"	 "1"
+			"count"	 "0"
 			"health"	"15000"
 			"is_boss"	"1"
 			"plugin"	"npc_random_zombie"
@@ -322,7 +322,7 @@
 		"1.0"
 		{
 			"cash"	"0"
-			"count"	 "2"
+			"count"	 "0"
 			"health"	"15000"
 			"is_boss"	"1"
 			"plugin"	"npc_random_zombie"
@@ -1291,7 +1291,7 @@
 		
 		"grigori_refresh_store"	"1"
 		"map_setup_fake"	"1"
-		"10.0"
+		"7.0"
 		{
 			"count"			"0"
 			"health"		"1000000"

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_infected_tomislav_main.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_infected_tomislav_main.sp
@@ -104,7 +104,7 @@ methodmap InfectedTomislavMain < CClotBody
 
 	public InfectedTomislavMain(float vecPos[3], float vecAng[3], int ally)
 	{
-		InfectedTomislavMain npc = view_as<InfectedTomislavMain>(CClotBody(vecPos, vecAng, "models/player/heavy.mdl", "1.0", "30000", ally));
+		InfectedTomislavMain npc = view_as<InfectedTomislavMain>(CClotBody(vecPos, vecAng, "models/player/heavy.mdl", "1.0", "15000", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		FormatEx(c_HeadPlaceAttachmentGibName[npc.index], sizeof(c_HeadPlaceAttachmentGibName[]), "head");

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_hmo.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_hmo.sp
@@ -116,7 +116,7 @@ methodmap Headcrabmilloperator < CClotBody
 	
 	public Headcrabmilloperator(float vecPos[3], float vecAng[3], int ally)
 	{
-		Headcrabmilloperator npc = view_as<Headcrabmilloperator>(CClotBody(vecPos, vecAng, "models/player/pyro.mdl", "1.0", "17500", ally));
+		Headcrabmilloperator npc = view_as<Headcrabmilloperator>(CClotBody(vecPos, vecAng, "models/player/pyro.mdl", "1.0", "8750", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_huntsman.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_huntsman.sp
@@ -104,7 +104,7 @@ methodmap ZSHuntsman < CClotBody
 	
 	public ZSHuntsman(float vecPos[3], float vecAng[3], int ally)
 	{
-		ZSHuntsman npc = view_as<ZSHuntsman>(CClotBody(vecPos, vecAng, "models/player/sniper.mdl", "1.0", "12500", ally));
+		ZSHuntsman npc = view_as<ZSHuntsman>(CClotBody(vecPos, vecAng, "models/player/sniper.mdl", "1.0", "6250", ally));
 
 		SetVariantInt(2);
 		AcceptEntityInput(npc.index, "SetBodyGroup");

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_medic_healer.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_medic_healer.sp
@@ -88,7 +88,7 @@ methodmap ZSMedicHealer < CClotBody
 	}
 	public ZSMedicHealer(float vecPos[3], float vecAng[3], int ally)
 	{
-		ZSMedicHealer npc = view_as<ZSMedicHealer>(CClotBody(vecPos, vecAng, "models/player/medic.mdl", "1.0", "15000", ally));
+		ZSMedicHealer npc = view_as<ZSMedicHealer>(CClotBody(vecPos, vecAng, "models/player/medic.mdl", "1.0", "7500", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_demoknight.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_demoknight.sp
@@ -77,7 +77,7 @@ methodmap InfectedDemoMain < CClotBody
 	}
 	public InfectedDemoMain(float vecPos[3], float vecAng[3], int ally)
 	{
-		InfectedDemoMain npc = view_as<InfectedDemoMain>(CClotBody(vecPos, vecAng, "models/player/demo.mdl", "1.0", "25000", ally));
+		InfectedDemoMain npc = view_as<InfectedDemoMain>(CClotBody(vecPos, vecAng, "models/player/demo.mdl", "1.0", "12500", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_engineer.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_engineer.sp
@@ -132,7 +132,7 @@ methodmap InfectedEngineer < CClotBody
 	
 	public InfectedEngineer(float vecPos[3], float vecAng[3], int ally)
 	{
-		InfectedEngineer npc = view_as<InfectedEngineer>(CClotBody(vecPos, vecAng, "models/player/engineer.mdl", "1.00", "20000", ally));
+		InfectedEngineer npc = view_as<InfectedEngineer>(CClotBody(vecPos, vecAng, "models/player/engineer.mdl", "1.00", "10000", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_heavy.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_heavy.sp
@@ -86,7 +86,7 @@ methodmap InfectedHeavy < CClotBody
 	
 	public InfectedHeavy(float vecPos[3], float vecAng[3], int ally)
 	{
-		InfectedHeavy npc = view_as<InfectedHeavy>(CClotBody(vecPos, vecAng, "models/player/heavy.mdl", "1.0", "30000", ally));
+		InfectedHeavy npc = view_as<InfectedHeavy>(CClotBody(vecPos, vecAng, "models/player/heavy.mdl", "1.0", "15000", ally));
 		
 		i_NpcWeight[npc.index] = 2;
 		npc.SetActivity("ACT_MP_RUN_MELEE");

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_scout.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_scout.sp
@@ -132,7 +132,7 @@ methodmap ZSscout < CClotBody
 	
 	public ZSscout(float vecPos[3], float vecAng[3], int ally)
 	{
-		ZSscout npc = view_as<ZSscout>(CClotBody(vecPos, vecAng, "models/player/scout.mdl", "1.0", "15000", ally));
+		ZSscout npc = view_as<ZSscout>(CClotBody(vecPos, vecAng, "models/player/scout.mdl", "1.0", "7500", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_sniper_jarate.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_sniper_jarate.sp
@@ -83,7 +83,7 @@ methodmap InfectedSniperjarate < CClotBody
 	
 	public InfectedSniperjarate(float vecPos[3], float vecAng[3], int ally)
 	{
-		InfectedSniperjarate npc = view_as<InfectedSniperjarate>(CClotBody(vecPos, vecAng, "models/player/sniper.mdl", "1.0", "22500", ally));
+		InfectedSniperjarate npc = view_as<InfectedSniperjarate>(CClotBody(vecPos, vecAng, "models/player/sniper.mdl", "1.0", "11250", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		npc.SetActivity("ACT_MP_RUN_MELEE");

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_soldier.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_soldier.sp
@@ -96,7 +96,7 @@ methodmap ZSoldierGrave < CClotBody
 	
 	public ZSoldierGrave(float vecPos[3], float vecAng[3], int ally)
 	{
-		ZSoldierGrave npc = view_as<ZSoldierGrave>(CClotBody(vecPos, vecAng, "models/player/soldier.mdl", "1.0", "30000", ally));
+		ZSoldierGrave npc = view_as<ZSoldierGrave>(CClotBody(vecPos, vecAng, "models/player/soldier.mdl", "1.0", "15000", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_soldier_pickaxe.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/45/npc_zs_zombie_soldier_pickaxe.sp
@@ -88,7 +88,7 @@ methodmap ZSsoldier < CClotBody
 	
 	public ZSsoldier(float vecPos[3], float vecAng[3], int ally)
 	{
-		ZSsoldier npc = view_as<ZSsoldier>(CClotBody(vecPos, vecAng, "models/player/soldier.mdl", "1.0", "40000", ally));
+		ZSsoldier npc = view_as<ZSsoldier>(CClotBody(vecPos, vecAng, "models/player/soldier.mdl", "1.0", "20000", ally));
 		
 		i_NpcWeight[npc.index] = 3;
 		npc.SetActivity("ACT_MP_RUN_MELEE");

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_cleaner.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_cleaner.sp
@@ -101,7 +101,7 @@ methodmap InfectedCleaner < CClotBody
 	
 	public InfectedCleaner(float vecPos[3], float vecAng[3], int ally)
 	{
-		InfectedCleaner npc = view_as<InfectedCleaner>(CClotBody(vecPos, vecAng, "models/player/pyro.mdl", "1.0", "50000", ally));
+		InfectedCleaner npc = view_as<InfectedCleaner>(CClotBody(vecPos, vecAng, "models/player/pyro.mdl", "1.0", "25000", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		FormatEx(c_HeadPlaceAttachmentGibName[npc.index], sizeof(c_HeadPlaceAttachmentGibName[]), "head");

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_eradicator.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_eradicator.sp
@@ -105,7 +105,7 @@ methodmap Eradicator < CClotBody
 	
 	public Eradicator(float vecPos[3], float vecAng[3], int ally)
 	{
-		Eradicator npc = view_as<Eradicator>(CClotBody(vecPos, vecAng, "models/zombie_riot/gmod_zs/zs_zombie_models_1_1.mdl", "1.15", "70000", ally, false));
+		Eradicator npc = view_as<Eradicator>(CClotBody(vecPos, vecAng, "models/zombie_riot/gmod_zs/zs_zombie_models_1_1.mdl", "1.15", "35000", ally, false));
 		
 		i_NpcWeight[npc.index] = 1;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_firefighter.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_firefighter.sp
@@ -124,7 +124,7 @@ methodmap InfectedFireFighter < CClotBody
 	
 	public InfectedFireFighter(float vecPos[3], float vecAng[3], int ally)
 	{
-		InfectedFireFighter npc = view_as<InfectedFireFighter>(CClotBody(vecPos, vecAng, "models/player/pyro.mdl", "1.0", "50000", ally, false, true));
+		InfectedFireFighter npc = view_as<InfectedFireFighter>(CClotBody(vecPos, vecAng, "models/player/pyro.mdl", "1.0", "12500", ally, false, true));
 		
 		i_NpcWeight[npc.index] = 3;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_ihbc.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_ihbc.sp
@@ -89,7 +89,7 @@ methodmap InfectedHazardous < CClotBody
 	
 	public InfectedHazardous(float vecPos[3], float vecAng[3], int ally)
 	{
-		InfectedHazardous npc = view_as<InfectedHazardous>(CClotBody(vecPos, vecAng, "models/player/medic.mdl", "1.0", "45000", ally));
+		InfectedHazardous npc = view_as<InfectedHazardous>(CClotBody(vecPos, vecAng, "models/player/medic.mdl", "1.0", "22500", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_manhattan_parrot.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_manhattan_parrot.sp
@@ -76,7 +76,7 @@ methodmap ManhattanParrot < CClotBody
 	}
 	public ManhattanParrot(float vecPos[3], float vecAng[3], int ally)
 	{
-		ManhattanParrot npc = view_as<ManhattanParrot>(CClotBody(vecPos, vecAng, "models/player/demo.mdl", "1.0", "30000", ally));
+		ManhattanParrot npc = view_as<ManhattanParrot>(CClotBody(vecPos, vecAng, "models/player/demo.mdl", "1.0", "15000", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_medic_main.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_medic_main.sp
@@ -131,7 +131,7 @@ methodmap InfectedBattleMedic < CClotBody
 	
 	public InfectedBattleMedic(float vecPos[3], float vecAng[3], int ally)
 	{
-		InfectedBattleMedic npc = view_as<InfectedBattleMedic>(CClotBody(vecPos, vecAng, "models/player/medic.mdl", "1.0", "40000", ally));
+		InfectedBattleMedic npc = view_as<InfectedBattleMedic>(CClotBody(vecPos, vecAng, "models/player/medic.mdl", "1.0", "20000", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_mlsm.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_mlsm.sp
@@ -98,7 +98,7 @@ methodmap MassShootingLover < CClotBody
 
 	public MassShootingLover(float vecPos[3], float vecAng[3], int ally)
 	{
-		MassShootingLover npc = view_as<MassShootingLover>(CClotBody(vecPos, vecAng, "models/player/soldier.mdl", "1.0", "50000", ally));
+		MassShootingLover npc = view_as<MassShootingLover>(CClotBody(vecPos, vecAng, "models/player/soldier.mdl", "1.0", "25000", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		FormatEx(c_HeadPlaceAttachmentGibName[npc.index], sizeof(c_HeadPlaceAttachmentGibName[]), "head");

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_sam.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_sam.sp
@@ -88,7 +88,7 @@ methodmap StoneAgeMaker < CClotBody
 	
 	public StoneAgeMaker(float vecPos[3], float vecAng[3], int ally)
 	{
-		StoneAgeMaker npc = view_as<StoneAgeMaker>(CClotBody(vecPos, vecAng, "models/player/soldier.mdl", "1.0", "40000", ally));
+		StoneAgeMaker npc = view_as<StoneAgeMaker>(CClotBody(vecPos, vecAng, "models/player/soldier.mdl", "1.0", "20000", ally));
 		
 		i_NpcWeight[npc.index] = 1;
 		FormatEx(c_HeadPlaceAttachmentGibName[npc.index], sizeof(c_HeadPlaceAttachmentGibName[]), "head");

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_sniper.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_sniper.sp
@@ -50,7 +50,7 @@ methodmap InfectedSniper < CClotBody
 
 	public InfectedSniper(float vecPos[3], float vecAng[3], int ally)
 	{
-		InfectedSniper npc = view_as<InfectedSniper>(CClotBody(vecPos, vecAng, "models/player/sniper.mdl", "1.0", "20000", ally));
+		InfectedSniper npc = view_as<InfectedSniper>(CClotBody(vecPos, vecAng, "models/player/sniper.mdl", "1.0", "10000", ally));
 		
 		i_NpcWeight[npc.index] = 2;
 		FormatEx(c_HeadPlaceAttachmentGibName[npc.index], sizeof(c_HeadPlaceAttachmentGibName[]), "head");

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_vile_poisonheadcrab_zombie.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_vile_poisonheadcrab_zombie.sp
@@ -125,7 +125,7 @@ methodmap ZSVILEPoisonheadcrabZombie < CClotBody
 	
 	public ZSVILEPoisonheadcrabZombie(float vecPos[3], float vecAng[3], int ally)
 	{
-		ZSVILEPoisonheadcrabZombie npc = view_as<ZSVILEPoisonheadcrabZombie>(CClotBody(vecPos, vecAng, "models/zombie/poison.mdl", "1.15", "80000", ally));
+		ZSVILEPoisonheadcrabZombie npc = view_as<ZSVILEPoisonheadcrabZombie>(CClotBody(vecPos, vecAng, "models/zombie/poison.mdl", "1.15", "40000", ally));
 		
 		i_NpcWeight[npc.index] = 2;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_zombie_breadmonster.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_zombie_breadmonster.sp
@@ -86,7 +86,7 @@ methodmap BreadMonster < CClotBody
 	
 	public BreadMonster(float vecPos[3], float vecAng[3], int ally)
 	{
-		BreadMonster npc = view_as<BreadMonster>(CClotBody(vecPos, vecAng, "models/player/heavy.mdl", "1.0", "50000", ally));
+		BreadMonster npc = view_as<BreadMonster>(CClotBody(vecPos, vecAng, "models/player/heavy.mdl", "1.0", "25000", ally));
 		
 		i_NpcWeight[npc.index] = 2;
 		npc.SetActivity("ACT_MP_RUN_MELEE");

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_zombie_fatscout.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_zombie_fatscout.sp
@@ -67,7 +67,7 @@ methodmap InfectedFatScout < CClotBody
 	
 	public InfectedFatScout(float vecPos[3], float vecAng[3], int ally, const char[] data)
 	{
-		InfectedFatScout npc = view_as<InfectedFatScout>(CClotBody(vecPos, vecAng, "models/player/heavy.mdl", "1.0", "60000", ally));
+		InfectedFatScout npc = view_as<InfectedFatScout>(CClotBody(vecPos, vecAng, "models/player/heavy.mdl", "1.0", "30000", ally));
 		
 		i_NpcWeight[npc.index] = 2;
 		int iActivity = npc.LookupActivity("ACT_MP_RUN_SECONDARY");

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_zombie_fatspy.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/60/npc_zs_zombie_fatspy.sp
@@ -86,7 +86,7 @@ methodmap InfectedFatSpy < CClotBody
 	
 	public InfectedFatSpy(float vecPos[3], float vecAng[3], int ally)
 	{
-		InfectedFatSpy npc = view_as<InfectedFatSpy>(CClotBody(vecPos, vecAng, "models/player/heavy.mdl", "1.0", "50000", ally));
+		InfectedFatSpy npc = view_as<InfectedFatSpy>(CClotBody(vecPos, vecAng, "models/player/heavy.mdl", "1.0", "25000", ally));
 		
 		i_NpcWeight[npc.index] = 2;
 		int iActivity = npc.LookupActivity("ACT_MP_RUN_MELEE_ALLCLASS");

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_zs_bonemesh.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_zs_bonemesh.sp
@@ -146,7 +146,7 @@ public void Bonemesh_ClotThink(int iNPC)
 	
 	if(npc.m_flNextRangedAttackHappening < GetGameTime())
 	{
-		npc.m_flNextRangedAttackHappening = GetGameTime() + 2.5;
+		npc.m_flNextRangedAttackHappening = GetGameTime() + 4;
 		DesertYadeamDoHealEffect(npc.index, 200.0);
 	}
 	if(npc.m_flNextDelayTime > GetGameTime(npc.index))

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_zs_flesh_creeper.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_zs_flesh_creeper.sp
@@ -863,6 +863,7 @@ public Action FleshCreeper_OnTakeDamage(int victim, int &attacker, int &inflicto
 public void FleshCreeper_NPCDeath(int entity)
 {
 	FleshCreeper npc = view_as<FleshCreeper>(entity);
+	SpawnMoney(npc.index, true);
 	if(!npc.m_bGib)
 	{
 		npc.PlayDeathSound();	

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_zs_nest.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_zs_nest.sp
@@ -358,30 +358,30 @@ public void Nest_ClotThink(int iNPC)
 
 				if(GetTeam(iNPC) == TFTeam_Red)
 				{
-					IncreaseSpawnRates *= 0.5;
+					IncreaseSpawnRates *= 0.8;
 				}
 				
 				if(i_currentwave[iNPC] < 15) {
 					int idx = GetRandomInt(0, sizeof(g_10wave) - 1);
 					strcopy(EnemyToSpawn, sizeof(EnemyToSpawn), g_10wave[idx]);
-					IncreaseSpawnRates *= 0.5;
+					//IncreaseSpawnRates *= 0.5;
 				} 
 				else if(i_currentwave[iNPC] < 28) {
 					int idx = GetRandomInt(0, sizeof(g_20wave) - 1);
 					strcopy(EnemyToSpawn, sizeof(EnemyToSpawn), g_20wave[idx]);
-					IncreaseSpawnRates *= 0.5;
+					//IncreaseSpawnRates *= 0.5;
 				}
 				else if(i_currentwave[iNPC] < 41)
 				{
 					int idx = GetRandomInt(0, sizeof(g_30wave) - 1);
 					strcopy(EnemyToSpawn, sizeof(EnemyToSpawn), g_30wave[idx]);
-					IncreaseSpawnRates *= 0.5;
+					//IncreaseSpawnRates *= 0.5;
 				}
 				else 
 				{
 					int idx = GetRandomInt(0, sizeof(g_40wave) - 1);
 					strcopy(EnemyToSpawn, sizeof(EnemyToSpawn), g_40wave[idx]);
-					IncreaseSpawnRates *= 0.5;
+					//IncreaseSpawnRates *= 0.5;
 				}
 				
 				if(Rogue_Mode())

--- a/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_zs_soldier_giant_grave.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/gmod_zs/special/npc_zs_soldier_giant_grave.sp
@@ -391,7 +391,7 @@ public void ZSSoldierGiant_ClotDamaged_Post(int victim, int attacker, int inflic
 				float pos[3]; GetEntPropVector(npc.index, Prop_Data, "m_vecAbsOrigin", pos);
 				float ang[3]; GetEntPropVector(npc.index, Prop_Data, "m_angRotation", ang);
 				
-				int spawn_index = NPC_CreateByName("npc_zombie_soldier_minion_grave", -1, pos, ang, GetTeam(npc.index));
+				int spawn_index = NPC_CreateByName("npc_zs_soldier_minion_grave", -1, pos, ang, GetTeam(npc.index));
 				if(spawn_index > MaxClients)
 				{
 					NpcStats_CopyStats(npc.index, spawn_index);


### PR DESCRIPTION
1. 웨이브 전체

1) 21~40 웨이브 일반 몹들 체력 50% 감소

2) 크리퍼 사살시 줏어먹을 수 있는 500원을 드랍함

3) 둥지에서 몹이 스폰되는 속도: 0.5 -> 0.8

2. 좀비들

1. 40웨이브 거대 소환사 솔저가 감실 버전의 레드팀 옷을 입은 미니언 솔저를 뱉던 현상 수정(스펙은 감실 버전과 동일하고 옷만 블루팀임)

2. 본매쉬 공격 주기: 2.5 -> 4

3. 10웨이브 이전 엘리트 좀비들은 인원수 관계 없이 무조건 1마리만 스폰함

4. 3웨이브 엘리트 좀비 체력: 15000 -> 10000

5. 스핑크스 소환 이후 다음 몹이 나오는데 까지 걸리는 시간: 10 -> 7