### PR TITLE
Weapons Maintenance

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -3689,7 +3689,6 @@
 				"pap_2_index"		"1098"
 				"pap_2_attributes"	"2 ; 27.0 ; 41 ; 1.5 ; 298 ; 2 ; 6 ; 2 ; 97 ; 1.0 ; 75 ; 999 ; 4057 ; 1"
 				"pap_2_ammo"		"16"	//Sniper ammo
-				"pap_2_func_attack2"	"Weapon_SupplyDrop"
 				"pap_2_weapon_archetype"	"2"
 				
 				"pap_2_lag_comp" 			"1"
@@ -3698,6 +3697,13 @@
 				"pap_2_lag_comp_dont_move_building" 	"0"
 				"pap_2_no_clip"				"1"
 				"pap_2_int_ability_onequip"		"3"
+				
+				"pap_2_func_mapstart"			"SniperSupply_OnMap"
+				//"pap_2_func_weaponcreated"		"Enable_ExploARWeapon"
+				"pap_2_func_ondeploy"			"SniperSupply_Deploy"
+				"pap_2_func_onholster"			"SniperSupply_Holster"
+				"pap_2_func_attack"				"Weapon_SniperRifle_M1"
+				"pap_4_func_attack3"			"MedigunChangeModeR"
 				
 				"pap_2_pappaths"	"1"
 				"pap_2_papskip"		"1"	// Skips Pap 3 & 4
@@ -3735,8 +3741,14 @@
 				"pap_4_index"		"1098"
 				"pap_4_attributes"	"2 ; 50.0 ; 6 ; 1.0 ; 41 ; 3.0 ; 97 ; 2 ; 75 ; 999 ; 4057 ; 1"
 				"pap_4_ammo"		"16"	//Sniper ammo
-				"pap_4_func_attack2"	"Weapon_SupplyDropElite"
-				"pap_4_func_onbuy"	"Weapon_EnableSmartBouncing"
+				
+				"pap_4_func_mapstart"			"SniperSupply_OnMap"
+				//"pap_4_func_weaponcreated"		"Enable_ExploARWeapon"
+				"pap_4_func_ondeploy"			"SniperSupply_Deploy"
+				"pap_4_func_onholster"			"SniperSupply_Holster"
+				"pap_4_func_onbuy"				"Weapon_EnableSmartBouncing"
+				"pap_4_func_attack"				"Weapon_SniperRifle_M1"
+				"pap_4_func_attack3"			"MedigunChangeModeR"
 				
 				"pap_4_lag_comp" 			"1"
 				"pap_4_lag_comp_collision" 		"0"
@@ -21641,7 +21653,7 @@
 			{
 				"desc"		"Magia Wings Desc"
 				"cost"		"0"
-				"textstore"	"Magia Wings [???]"
+				"textstore"	"Originium"
 				"visual_desc_only"	"0"
 				"attributes"	"2 ; 1.0"
 				"index"		"2" //0 = primary, 1 = secondary, 2 = melee, 3 = Body, 4 = mage?
@@ -21651,7 +21663,7 @@
 			{
 				"desc"		"Silvester Wings Desc"
 				"cost"		"0"
-				"textstore"	"Silvester Wings [???]"
+				"textstore"	"Originium"
 				"visual_desc_only"	"0"
 				"attributes"	"2 ; 1.0"
 				"index"		"2" //0 = primary, 1 = secondary, 2 = melee, 3 = Body, 4 = mage?

--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -1262,7 +1262,7 @@
 				
 				"pap_7_classname"						"tf_weapon_smg"
 				"pap_7_index"							"211"
-				"pap_7_attributes"						"45 ; 2 ; 2 ; 40.1 ; 6 ; 0.85 ; 303 ; -1 ; 106 ; 0.7 ; 834 ; 420"
+				"pap_7_attributes"						"45 ; 2 ; 2 ; 40.1 ; 6 ; 0.85 ; 303 ; -1 ; 106 ; 0.7 ; 4 ; 1.0 ; 1 ; 1.0 ; 5 ; 1.0 ; 834 ; 420"
 				"pap_7_ammo"							"18"
 				
 				"pap_7_weapon_archetype"				"4"

--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -3687,7 +3687,7 @@
 				"pap_2_damage_falloff"	"1.0" //The amount of damage that is reduced for every 1000 units, the default is 0.9
 				"pap_2_classname"	"tf_weapon_sniperrifle_classic"
 				"pap_2_index"		"1098"
-				"pap_2_attributes"	"2 ; 27.0 ; 41 ; 1.5 ; 298 ; 2 ; 6 ; 2 ; 97 ; 1.0 ; 75 ; 999 ; 4057 ; 1"
+				"pap_2_attributes"	"2 ; 27.0 ; 41 ; 1.5 ; 298 ; 2 ; 6 ; 2 ; 97 ; 1.0 ; 75 ; 999 ; 4057 ; 1 ; 122 ; 1.0"
 				"pap_2_ammo"		"16"	//Sniper ammo
 				"pap_2_weapon_archetype"	"2"
 				
@@ -3702,8 +3702,8 @@
 				//"pap_2_func_weaponcreated"		"Enable_ExploARWeapon"
 				"pap_2_func_ondeploy"			"SniperSupply_Deploy"
 				"pap_2_func_onholster"			"SniperSupply_Holster"
-				"pap_2_func_attack"				"Weapon_SniperRifle_M1"
-				"pap_4_func_attack3"			"MedigunChangeModeR"
+				"pap_2_func_attack"				"SniperSupply_M1"
+				"pap_2_func_attack3"			"SniperSupply_R"
 				
 				"pap_2_pappaths"	"1"
 				"pap_2_papskip"		"1"	// Skips Pap 3 & 4
@@ -3739,7 +3739,7 @@
 				"pap_4_damage_falloff"	"1.0" //The amount of damage that is reduced for every 1000 units, the default is 0.9
 				"pap_4_classname"	"tf_weapon_sniperrifle_classic"
 				"pap_4_index"		"1098"
-				"pap_4_attributes"	"2 ; 50.0 ; 6 ; 1.0 ; 41 ; 3.0 ; 97 ; 2 ; 75 ; 999 ; 4057 ; 1"
+				"pap_4_attributes"	"2 ; 50.0 ; 6 ; 1.0 ; 41 ; 3.0 ; 97 ; 2 ; 75 ; 999 ; 4057 ; 1 ; 122 ; 2.0"
 				"pap_4_ammo"		"16"	//Sniper ammo
 				
 				"pap_4_func_mapstart"			"SniperSupply_OnMap"
@@ -3747,8 +3747,8 @@
 				"pap_4_func_ondeploy"			"SniperSupply_Deploy"
 				"pap_4_func_onholster"			"SniperSupply_Holster"
 				"pap_4_func_onbuy"				"Weapon_EnableSmartBouncing"
-				"pap_4_func_attack"				"Weapon_SniperRifle_M1"
-				"pap_4_func_attack3"			"MedigunChangeModeR"
+				"pap_4_func_attack"				"SniperSupply_M1"
+				"pap_4_func_attack3"			"SniperSupply_R"
 				
 				"pap_4_lag_comp" 			"1"
 				"pap_4_lag_comp_collision" 		"0"
@@ -21653,7 +21653,7 @@
 			{
 				"desc"		"Magia Wings Desc"
 				"cost"		"0"
-				"textstore"	"Originium"
+				"textstore"	"Magia Wings [???]"
 				"visual_desc_only"	"0"
 				"attributes"	"2 ; 1.0"
 				"index"		"2" //0 = primary, 1 = secondary, 2 = melee, 3 = Body, 4 = mage?
@@ -21663,7 +21663,7 @@
 			{
 				"desc"		"Silvester Wings Desc"
 				"cost"		"0"
-				"textstore"	"Originium"
+				"textstore"	"Magia Wings [???]"
 				"visual_desc_only"	"0"
 				"attributes"	"2 ; 1.0"
 				"index"		"2" //0 = primary, 1 = secondary, 2 = melee, 3 = Body, 4 = mage?

--- a/addons/sourcemod/scripting/shared/custom/joke_medigun_mod_drain_health.sp
+++ b/addons/sourcemod/scripting/shared/custom/joke_medigun_mod_drain_health.sp
@@ -91,14 +91,17 @@ bool NeedCrouchAbility(int client)
 	}
 	return NeedCrouch;
 }
-
 public void MedigunChangeModeR(int client, int weapon, bool crit, int slot)
 {
-	MedigunChangeModeRInternal(client, weapon, crit, slot);
-}
 
-public void MedigunChangeModeRInternal(int client, int weapon, bool crit, int slot)
+	MedigunChangeModeRInternal(client, weapon, crit, slot, false);
+}
+public void MedigunChangeModeRInternal(int client, int weapon, bool crit, int slot, bool checkCrouch)
 {
+	//only swithc with crouch R
+	if(checkCrouch && !(GetClientButtons(client) & IN_DUCK))
+		return;
+
 	if(b_MediunDamageModeSet[client])
 	{
 		b_MediunDamageModeSet[client] = false;
@@ -112,7 +115,6 @@ public void MedigunChangeModeRInternal(int client, int weapon, bool crit, int sl
 	Medigun_SetModeDo(client, weapon);
 	medigun_hud_delay[client] = 0.0; //update hud fast
 }
-
 public void Medigun_SetModeDo(int client, int weapon)
 {
 	if(!b_IsAMedigun[weapon])
@@ -657,6 +659,7 @@ stock int CreateParticleOnBackPack(const char[] sParticle, int client)
 	return entity;
 }
 
+
 float MedigunGetUberDuration(int owner)
 {
 	//so it starts at 1.0
@@ -691,22 +694,23 @@ float MedigunGetUberDuration(int owner)
 	return Attribute;
 }
 
+
 public void Adaptive_MedigunChangeBuff(int client, int weapon, bool crit, int slot)
 {
-	// If I crouch, change medigun mode.
+	//only swithc with crouch R
 	if(GetClientButtons(client) & IN_DUCK)
 	{
-		MedigunChangeModeRInternal(client, weapon, crit, slot);
+		MedigunChangeModeRInternal(client, weapon, crit, slot, NeedCrouchAbility(client));
 		return;
 	}
-	
 	ClientCommand(client, "playgamesound weapons/vaccinator_toggle.wav");
 	MedigunModeSet[client]++;
-	if(MedigunModeSet[client] > 2)
+	if(MedigunModeSet[client] > 1)
 	{
 		MedigunModeSet[client] = 0;
 	}
 }
+
 
 public void ReduceMediFluidCost(int client, int &cost)
 {

--- a/addons/sourcemod/scripting/shared/custom/joke_medigun_mod_drain_health.sp
+++ b/addons/sourcemod/scripting/shared/custom/joke_medigun_mod_drain_health.sp
@@ -378,6 +378,11 @@ public MRESReturn OnMedigunPostFramePost(int medigun) {
 								ApplyStatusEffect(owner, owner, "Healing Adaptiveness Ranged", 0.15);
 								ApplyStatusEffect(owner, healTarget, "Healing Adaptiveness Ranged", 0.15);
 							}
+							case 2:
+							{
+								ApplyStatusEffect(owner, owner, "Healing Adaptiveness All", 0.15);
+								ApplyStatusEffect(owner, healTarget, "Healing Adaptiveness All", 0.15);
+							}
 						}
 					}
 #if defined ZR
@@ -693,14 +698,14 @@ float MedigunGetUberDuration(int owner)
 public void Adaptive_MedigunChangeBuff(int client, int weapon, bool crit, int slot)
 {
 	//only swithc with crouch R
-	if(NeedCrouchAbility(client))
+	if(GetClientButtons(client) & IN_DUCK)
 	{
 		MedigunChangeModeRInternal(client, weapon, crit, slot, NeedCrouchAbility(client));
 		return;
 	}
 	ClientCommand(client, "playgamesound weapons/vaccinator_toggle.wav");
 	MedigunModeSet[client]++;
-	if(MedigunModeSet[client] > 1)
+	if(MedigunModeSet[client] > 2)
 	{
 		MedigunModeSet[client] = 0;
 	}

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -871,7 +871,7 @@ float Barricade_Stabilizer_ResistanceFunc(int attacker, int victim, StatusEffect
 		{
 			if(!CheckInHud())
 			{
-				int health = GetEntProp(building, Prop_Data, "m_iHealth") - RoundToCeil(basedamage *(RaidbossIgnoreBuildingsLogic(1) ? 1.5 : 1.0)
+				int health = GetEntProp(building, Prop_Data, "m_iHealth") - RoundToCeil(basedamage *(RaidbossIgnoreBuildingsLogic(1) ? 1.0 : 0.5)
 				* (b_DecorativeObject ? 1.0 : 2.0) * (b_ExplosiveBarrel ? 1.0 : 5.0));
 				if(health > 0)
 				{
@@ -936,7 +936,7 @@ void Barricade_Stabilizer_Hud_Func(int attacker, int victim, StatusEffect Apply_
 		}
 	}
 	if(b_ExplosiveBarrel)
-		Format(HudToDisplay, SizeOfChar, "[☢ WTF]");
+		Format(HudToDisplay, SizeOfChar, "[☢ %.0f％]", Ratio);
 	else
 		Format(HudToDisplay, SizeOfChar, "[⛉ %.0f％]", Ratio);
 	#endif

--- a/addons/sourcemod/scripting/zombie_riot/custom/addons/weapon_mini_semi_gun.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/addons/weapon_mini_semi_gun.sp
@@ -2,17 +2,20 @@
 #pragma newdecls required
 static float OverheatingFeedBack_RestTime[MAXPLAYERS];
 static float OverheatingFeedBack_HudTime[MAXPLAYERS];
+static float OverheatingFeedBack_MeltdownTime[MAXPLAYERS];
 static int OverheatingFeedBack_Charge[MAXPLAYERS];
 static int OverheatingFeedBack_Sounds[MAXPLAYERS];
 static bool OverheatingFeedBack_FullCharge[MAXPLAYERS];
 static bool OverheatingFeedBack_Overclocking[MAXPLAYERS];
+static bool OverheatingFeedBack_FullMeltdown[MAXPLAYERS];
 
 static const char Minisemi_SoundLists[][] = {
 	"weapons/sniper_railgun_bolt_back.wav",
 	"weapons/syringegun_reload_air2.wav",
 	"weapons/syringegun_reload_air1.wav",
 	"misc/hologram_start.wav",
-	"items/powerup_pickup_reflect_reflect_damage.wav"
+	"items/powerup_pickup_reflect_reflect_damage.wav",
+	"player/medic_charged_death.wav"
 };
 
 public void Custom_Mini_Semi_Gun_MapStart()
@@ -21,8 +24,10 @@ public void Custom_Mini_Semi_Gun_MapStart()
 	Zero(OverheatingFeedBack_Charge);
 	Zero(OverheatingFeedBack_FullCharge);
 	Zero(OverheatingFeedBack_Overclocking);
+	Zero(OverheatingFeedBack_FullMeltdown);
 	ZeroFloat(OverheatingFeedBack_RestTime);
 	ZeroFloat(OverheatingFeedBack_HudTime);
+	ZeroFloat(OverheatingFeedBack_MeltdownTime);
 	
 	PrecacheSoundArray(Minisemi_SoundLists);
 }
@@ -36,7 +41,10 @@ public void Weapon_Mini_Semi_Gun_OverheatingFeedBack_M1(int client, int weapon, 
 			TF2_RemoveCondition(client, TFCond_FocusBuff);
 		OverheatingFeedBack_Charge[client]=0;
 		OverheatingFeedBack_Sounds[client]=0;
+		if(OverheatingFeedBack_FullCharge[client])
+			Attributes_Set(weapon, 5, 1.0);
 		OverheatingFeedBack_FullCharge[client]=false;
+		OverheatingFeedBack_FullMeltdown[client]=false;
 		CreateTimer(0.1, Timer_ChangeStartSound, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE|TIMER_REPEAT);
 	}
 	OverheatingFeedBack_Charge[client]+=(OverheatingFeedBack_Overclocking[client] ? 2 : 1);
@@ -55,16 +63,39 @@ public void Weapon_Mini_Semi_Gun_OverheatingFeedBack_M1(int client, int weapon, 
 	SetGlobalTransTarget(client);
 	if(Ratio==(OverheatingFeedBack_Overclocking[client] ? 2.0 : 1.0))
 	{
+		if(OverheatingFeedBack_MeltdownTime[client]<GameTime && !OverheatingFeedBack_FullMeltdown[client])
+		{
+			Attributes_Set(weapon, 5, 1.375);
+			EmitSoundToClient(client, Minisemi_SoundLists[5]);
+			OverheatingFeedBack_FullMeltdown[client]=true;
+		}
 		if(OverheatingFeedBack_HudTime[client]<GameTime)
 		{
 			TF2_AddCondition(client, TFCond_FocusBuff, Attributes_Get(weapon, 6, 0.25) *0.4);
 			OverheatingFeedBack_HudTime[client] = GameTime+0.5;
 			if(OverheatingFeedBack_Overclocking[client])
-				PrintHintText(client, "%t",
-				"Custom Mini Semi Gun: Overheating FeedBack - Overclocking MAX");
+			{
+				if(OverheatingFeedBack_FullMeltdown[client])
+					PrintHintText(client, "%t\n%t\n%t",
+					"Custom Mini Semi Gun: Overheating FeedBack - Overclocking",
+					"Custom Mini Semi Gun: Overheating FeedBack - MAX", 
+					"Custom Mini Semi Gun: Overheating FeedBack - Fully Meltdown");
+				else
+					PrintHintText(client, "%t\n%t\n%t",
+					"Custom Mini Semi Gun: Overheating FeedBack - Overclocking", "Custom Mini Semi Gun: Overheating FeedBack - MAX", 
+					"Custom Mini Semi Gun: Overheating FeedBack - Meltdown in", RoundToCeil(OverheatingFeedBack_MeltdownTime[client]-GameTime));
+			}
 			else
-				PrintHintText(client, "%t",
-				"Custom Mini Semi Gun: Overheating FeedBack - MAX");
+			{
+				if(OverheatingFeedBack_FullMeltdown[client])
+					PrintHintText(client, "%t\n%t",
+					"Custom Mini Semi Gun: Overheating FeedBack - MAX", 
+					"Custom Mini Semi Gun: Overheating FeedBack - Fully Meltdown");
+				else
+					PrintHintText(client, "%t\n%t",
+					"Custom Mini Semi Gun: Overheating FeedBack - MAX", 
+					"Custom Mini Semi Gun: Overheating FeedBack - Meltdown in", RoundToCeil(OverheatingFeedBack_MeltdownTime[client]-GameTime));
+			}
 		}
 		if(!OverheatingFeedBack_FullCharge[client])
 		{
@@ -74,18 +105,46 @@ public void Weapon_Mini_Semi_Gun_OverheatingFeedBack_M1(int client, int weapon, 
 	}
 	else
 	{
+		OverheatingFeedBack_MeltdownTime[client]=GameTime + (11.75*Attributes_Get(weapon, 4, 1.0));
 		if(OverheatingFeedBack_HudTime[client]<GameTime)
 		{
 			OverheatingFeedBack_HudTime[client] = GameTime+0.5;
 			if(OverheatingFeedBack_Overclocking[client])
-				PrintHintText(client, "%t [%.0f％]",
-				"Custom Mini Semi Gun: Overheating FeedBack - Overclocking Charge",100.0*Ratio);
+			{
+				if(OverheatingFeedBack_FullMeltdown[client])
+				{
+					PrintHintText(client, "%t\n%t [%.0f％]\n%t",
+					"Custom Mini Semi Gun: Overheating FeedBack - Overclocking",
+					"Custom Mini Semi Gun: Overheating FeedBack - Charge",100.0*Ratio,
+					"Custom Mini Semi Gun: Overheating FeedBack - Fully Meltdown");
+				}
+				else
+				{
+					PrintHintText(client, "%t\n%t [%.0f％]",
+					"Custom Mini Semi Gun: Overheating FeedBack - Overclocking",
+					"Custom Mini Semi Gun: Overheating FeedBack - Charge",100.0*Ratio);
+				}
+				
+			}
 			else
-				PrintHintText(client, "%t [%.0f％]",
-				"Custom Mini Semi Gun: Overheating FeedBack - Charge",100.0*Ratio);
+			{
+				if(OverheatingFeedBack_FullMeltdown[client])
+				{
+					PrintHintText(client, "%t [%.0f％]\n%t",
+					"Custom Mini Semi Gun: Overheating FeedBack - Charge",100.0*Ratio,
+					"Custom Mini Semi Gun: Overheating FeedBack - Fully Meltdown");
+				}
+				else
+				{
+					PrintHintText(client, "%t [%.0f％]",
+					"Custom Mini Semi Gun: Overheating FeedBack - Charge",100.0*Ratio);
+				}
+			}
 		}
 	}
 	OverheatingFeedBack_RestTime[client] = GameTime + Attributes_Get(weapon, 6, 0.25) *0.4;
+	if(OverheatingFeedBack_FullMeltdown[client])
+		Ratio*=0.5;
 	Attributes_Set(weapon, 1, Ratio+1.0);
 	float spread = 0.7-(0.35*Ratio);
 	if(spread < 0.3)spread = 0.3;
@@ -105,7 +164,7 @@ public void Weapon_Mini_Semi_Gun_OverheatingFeedBack_M2(int client, int weapon, 
 		ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Ability has cooldown", Ability_CD);
 		return;
 	}
-	float SetCoolDown = 15.0+(60.0 * CooldownReductionAmount(client));
+	float SetCoolDown = 15.0+(45.0 * CooldownReductionAmount(client));
 	Rogue_OnAbilityUse(client, weapon);
 	Ability_Apply_Cooldown(client, slot, SetCoolDown, .ignoreCooldown=true);
 	Ability_Apply_Cooldown(client, 1, 15.0, .ignoreCooldown=true);

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_slug_rifle.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_slug_rifle.sp
@@ -3,7 +3,7 @@
 
 float Uranium_TimeTillBigHit[MAXPLAYERS][MAXENTITIES];
 
-static bool SniperRifle_HeadShot[MAXPLAYERS];
+bool SniperRifle_HeadShot[MAXPLAYERS];
 static int SniperRifle_Ignore[MAXPLAYERS];
 static float SniperRifle_ExplodDMG[MAXPLAYERS];
 static float SniperRifle_Charge[MAXPLAYERS];

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_slug_rifle.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_slug_rifle.sp
@@ -64,7 +64,6 @@ public void Weapon_SniperRifle_M1(int client, int weapon, bool crit, int slot)
 		}
 		delete trace;
 	}
-
 }
 
 void WeaponUranium_OnTakeDamage(int attacker,int victim, float &damage, float damagePosition[3])

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_sniper_monkey.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_sniper_monkey.sp
@@ -4,15 +4,18 @@
 static bool SmartBounce;
 static int LastHitTarget;
 static int SuppliesUsed;
+static bool SniperSupply_DropPerWave[MAXPLAYERS];
 
 void SniperMonkey_ResetUses()
 {
 	SuppliesUsed = 0;
+	Zero(SniperSupply_DropPerWave);
 }
 void SniperMonkey_ClearAll()
 {
 	SmartBounce = false;
 	SuppliesUsed = 0;
+	Zero(SniperSupply_DropPerWave);
 }
 
 float SniperMonkey_BouncingBullets(int victim, int &attacker, int &inflictor, float damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3])
@@ -291,5 +294,123 @@ public void Weapon_SupplyDropElite(int client, int weapon, bool &result, int slo
 		SetDefaultHudPosition(client);
 		SetGlobalTransTarget(client);
 		ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Ability has cooldown", Ability_CD);	
+	}
+}
+
+
+static Handle SniperSupply_Management[MAXPLAYERS] = {null, ...};
+
+public void SniperSupply_OnMap(int client, int weapon)
+{
+	Zero(SniperSupply_DropPerWave);
+}
+
+public void SniperSupply_Deploy(int client, int weapon)
+{
+	if(SniperSupply_Management[client] != null)
+	{
+		delete SniperSupply_Management[client];
+		SniperSupply_Management[client] = null;
+		DataPack pack;
+		SniperSupply_Management[client] = CreateDataTimer(0.1, Timer_Management_SniperSupply, pack, TIMER_REPEAT);
+		pack.WriteCell(client);
+		pack.WriteCell(weapon);
+	}
+	else
+	{
+		DataPack pack;
+		SniperSupply_Management[client] = CreateDataTimer(0.1, Timer_Management_SniperSupply, pack, TIMER_REPEAT);
+		pack.WriteCell(client);
+		pack.WriteCell(weapon);
+	}
+}
+
+public void SniperSupply_Holster(int client)
+{
+	if(SniperSupply_Management[client] != null)
+	{
+		delete SniperSupply_Management[client];
+		SniperSupply_Management[client] = null;
+	}
+}
+
+static Action Timer_Management_SniperSupply(Handle timer, DataPack pack)
+{
+	pack.Reset();
+	int client = pack.ReadCell();
+	int weapon = pack.ReadCell();
+	if(!IsValidClient(client) || !IsClientInGame(client) || !IsPlayerAlive(client) || !IsValidEntity(weapon))
+	{
+		if(SniperSupply_Management[client] != null)
+		{
+			delete SniperSupply_Management[client];
+			SniperSupply_Management[client] = null;
+		}
+		return Plugin_Stop;
+	}
+	
+	if(Ability_Check_Cooldown(client, 1) <= 0.0 && !SniperSupply_DropPerWave[client])
+	{
+		int target = -1;
+		for(int entitycount; entitycount<i_MaxcountNpcTotal; entitycount++)
+		{
+			int entity = EntRefToEntIndexFast(i_ObjectsNpcsTotal[entitycount]);
+			if(IsValidEntity(entity) && !b_NpcHasDied[entity] && b_NpcForcepowerupspawn[entity] != 2 && GetTeam(entity) != TFTeam_Red
+			&& !b_thisNpcIsARaid[entity] && !b_thisNpcIsABoss[entity])
+			{
+				target = entity;
+				break;
+			}
+		}
+		
+		if(target != -1)
+		{
+			b_NpcForcepowerupspawn[target] = 2;
+			CClotBody npc = view_as<CClotBody>(target);
+			if(!IsValidEntity(npc.m_iTeamGlow))
+			{
+				Update_TransmitState(target);
+				npc.m_iTeamGlow = TF2_CreateGlow(target);
+				
+				SetVariantColor(view_as<int>({125, 200, 255, 200}));
+				AcceptEntityInput(npc.m_iTeamGlow, "SetGlowColor");
+			}
+			else
+			{
+				if(IsValidEntity(npc.m_iTeamGlow)) 
+				{
+					Update_TransmitState(target);
+					SetVariantColor(view_as<int>({125, 200, 255, 200}));
+					AcceptEntityInput(npc.m_iTeamGlow, "SetGlowColor");
+				}		
+			}
+			ClientCommand(client, "playgamesound ui/quest_status_tick_expert_friend.wav");
+			Ability_Apply_Cooldown(client, 1, 90.0);
+			SniperSupply_DropPerWave[client]=true;
+		}
+		else
+			Ability_Apply_Cooldown(client, 1, 5.0, .ignoreCooldown=true);
+	}
+	
+	return Plugin_Continue;
+}
+
+public void SniperSupply_R(int client, int weapon, bool crit, int slot)
+{
+	if(SniperSupply_Management[client] != null)
+	{
+		delete SniperSupply_Management[client];
+		SniperSupply_Management[client] = null;
+		DataPack pack;
+		SniperSupply_Management[client] = CreateDataTimer(0.1, Timer_Management_SniperSupply, pack, TIMER_REPEAT);
+		pack.WriteCell(client);
+		pack.WriteCell(weapon);
+	}
+	else
+	{
+		DataPack pack;
+		SniperSupply_Management[client] = CreateDataTimer(0.1, Timer_Management_SniperSupply, pack, TIMER_REPEAT);
+		pack.WriteCell(client);
+		pack.WriteCell(weapon);
 	}
 }

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_sniper_monkey.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_sniper_monkey.sp
@@ -296,8 +296,6 @@ public void Weapon_SupplyDropElite(int client, int weapon, bool &result, int slo
 		ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Ability has cooldown", Ability_CD);	
 	}
 }
-
-
 static Handle SniperSupply_Management[MAXPLAYERS] = {null, ...};
 
 public void SniperSupply_OnMap(int client, int weapon)
@@ -348,6 +346,8 @@ static Action Timer_Management_SniperSupply(Handle timer, DataPack pack)
 		}
 		return Plugin_Stop;
 	}
+	if(CvarInfiniteCash.BoolValue)
+		SniperSupply_DropPerWave[client]=false;
 	
 	if(Ability_Check_Cooldown(client, 1) <= 0.0 && !SniperSupply_DropPerWave[client])
 	{
@@ -356,7 +356,8 @@ static Action Timer_Management_SniperSupply(Handle timer, DataPack pack)
 		{
 			int entity = EntRefToEntIndexFast(i_ObjectsNpcsTotal[entitycount]);
 			if(IsValidEntity(entity) && !b_NpcHasDied[entity] && b_NpcForcepowerupspawn[entity] != 2 && GetTeam(entity) != TFTeam_Red
-			&& !b_thisNpcIsARaid[entity] && !b_thisNpcIsABoss[entity])
+			&& GetTeam(entity) != TFTeam_Stalkers && !b_ThisEntityIgnored[entity] && !b_NpcIsInvulnerable[entity] && !b_thisNpcIsARaid[entity] && !b_thisNpcIsABoss[entity]
+			&& !b_StaticNPC[entity] && !b_ThisEntityIgnoredByOtherNpcsAggro[entity])
 			{
 				target = entity;
 				break;
@@ -369,22 +370,25 @@ static Action Timer_Management_SniperSupply(Handle timer, DataPack pack)
 			CClotBody npc = view_as<CClotBody>(target);
 			if(!IsValidEntity(npc.m_iTeamGlow))
 			{
+				npc.m_bTeamGlowDefault = false;
 				Update_TransmitState(target);
 				npc.m_iTeamGlow = TF2_CreateGlow(target);
 				
-				SetVariantColor(view_as<int>({125, 200, 255, 200}));
+				SetVariantColor(view_as<int>({136, 200, 5, 200}));
 				AcceptEntityInput(npc.m_iTeamGlow, "SetGlowColor");
 			}
 			else
 			{
 				if(IsValidEntity(npc.m_iTeamGlow)) 
 				{
+					npc.m_bTeamGlowDefault = false;
 					Update_TransmitState(target);
-					SetVariantColor(view_as<int>({125, 200, 255, 200}));
+					SetVariantColor(view_as<int>({136, 200, 5, 200}));
 					AcceptEntityInput(npc.m_iTeamGlow, "SetGlowColor");
 				}		
 			}
 			ClientCommand(client, "playgamesound ui/quest_status_tick_expert_friend.wav");
+			Rogue_OnAbilityUse(client, weapon);
 			Ability_Apply_Cooldown(client, 1, 90.0);
 			SniperSupply_DropPerWave[client]=true;
 		}
@@ -395,22 +399,100 @@ static Action Timer_Management_SniperSupply(Handle timer, DataPack pack)
 	return Plugin_Continue;
 }
 
+public void SniperSupply_M1(int client, int weapon, bool crit, int slot)
+{
+	static float vAngles[3], vOrigin[3];
+	GetClientEyePosition(client, vOrigin);
+	GetClientEyeAngles(client, vAngles);
+	Handle trace = TR_TraceRayFilterEx(vOrigin, vAngles, MASK_SHOT, RayType_Infinite, BulletAndMeleeTrace, client);
+	if(TR_GetFraction(trace) < 1.0)
+	{
+		TR_GetEndPosition(vOrigin, trace);
+		int target = TR_GetEntityIndex(trace);
+		if(target > 0 && !b_CannotBeHeadshot[target])
+		{
+			if(TR_GetHitGroup(trace) == HITGROUP_HEAD)
+			{
+				DisplayCritAboveNpc(target, client, true);
+				SniperRifle_HeadShot[client]=true;
+			}
+		}
+	}
+	delete trace;
+	if(SniperRifle_HeadShot[client])
+	{
+		if(i_CurrentEquippedPerk[client] & PERK_MARKSMAN_BEER
+		|| i_CurrentEquippedPerk[client] & PERK_MARKSMAN_BEER_X)
+		{
+			float Ability_CD = Ability_Check_Cooldown(client, 3)-3.0;
+			if(Ability_CD <= 0.0)
+				Ability_CD = 0.0;
+			Ability_Apply_Cooldown(client, 3, Ability_CD, .ignoreCooldown=true);
+			Ability_CD = Ability_Check_Cooldown(client, 1)-5.0;
+			if(Ability_CD <= 0.0)
+				Ability_CD = 0.0;
+			Ability_Apply_Cooldown(client, 1, Ability_CD, .ignoreCooldown=true);
+		}
+		SniperRifle_HeadShot[client]=false;
+	}
+	if(TF2_IsPlayerInCondition(client, TFCond_FocusBuff))
+	{
+		int KITER_Pack=RandomPickup_SpawnPickup(vOrigin);
+		if(IsValidEntity(KITER_Pack))
+		{
+			int MaxPickups = 8;
+			if(ZR_Get_Modifier() == KITERS_DREAM)
+				MaxPickups *= 2;
+			CClotBody npc = view_as<CClotBody>(KITER_Pack);
+			if(!IsValidEntity(npc.m_iTeamGlow))
+			{
+				npc.m_bTeamGlowDefault = false;
+				Update_TransmitState(KITER_Pack);
+				npc.m_iTeamGlow = TF2_CreateGlow(KITER_Pack);
+				
+				SetVariantColor(view_as<int>({136, 200, 5, 200}));
+				AcceptEntityInput(npc.m_iTeamGlow, "SetGlowColor");
+				CreateTimer(45.0 * MaxPickups, Timer_RemoveEntity, EntIndexToEntRef(npc.m_iTeamGlow), TIMER_FLAG_NO_MAPCHANGE);
+			}
+			else
+			{
+				if(IsValidEntity(npc.m_iTeamGlow)) 
+				{
+					npc.m_bTeamGlowDefault = false;
+					Update_TransmitState(KITER_Pack);
+					SetVariantColor(view_as<int>({136, 200, 5, 200}));
+					AcceptEntityInput(npc.m_iTeamGlow, "SetGlowColor");
+					CreateTimer(45.0 * MaxPickups, Timer_RemoveEntity, EntIndexToEntRef(npc.m_iTeamGlow), TIMER_FLAG_NO_MAPCHANGE);
+				}		
+			}
+			if(Ability_Check_Cooldown(client, 3) < 999.0 && Attributes_Get(weapon, Attrib_PapNumber, 0.0)==2)
+				Ability_Apply_Cooldown(client, 3, 9999999.0, .ignoreCooldown=true);
+			else
+				Ability_Apply_Cooldown(client, 3, 60.0);
+			vOrigin[2] += 5.0;
+			spawnRing_Vectors(vOrigin, 0.0, 0.0, 0.0, 0.0, LASERBEAM, 0, 255, 0, 255, 5, 0.5, 3.0, 1.0, 3, 150.0);
+			ClientCommand(client, "playgamesound ui/medic_alert.wav");
+			TF2_RemoveCondition(client, TFCond_FocusBuff);
+		}
+	}
+}
+
 public void SniperSupply_R(int client, int weapon, bool crit, int slot)
 {
-	if(SniperSupply_Management[client] != null)
+	float Ability_CD = Ability_Check_Cooldown(client, slot);
+	
+	if(Ability_CD <= 0.0 || CvarInfiniteCash.BoolValue)
+		Ability_CD = 0.0;
+	if(Ability_CD <= 0.0 || Ability_CD > 999.0)
 	{
-		delete SniperSupply_Management[client];
-		SniperSupply_Management[client] = null;
-		DataPack pack;
-		SniperSupply_Management[client] = CreateDataTimer(0.1, Timer_Management_SniperSupply, pack, TIMER_REPEAT);
-		pack.WriteCell(client);
-		pack.WriteCell(weapon);
+		if(TF2_IsPlayerInCondition(client, TFCond_FocusBuff))
+			TF2_RemoveCondition(client, TFCond_FocusBuff);
+		else
+			TF2_AddCondition(client, TFCond_FocusBuff, 5.0);
+		return;
 	}
-	else
-	{
-		DataPack pack;
-		SniperSupply_Management[client] = CreateDataTimer(0.1, Timer_Management_SniperSupply, pack, TIMER_REPEAT);
-		pack.WriteCell(client);
-		pack.WriteCell(weapon);
-	}
+	ClientCommand(client, "playgamesound items/medshotno1.wav");
+	SetDefaultHudPosition(client);
+	SetGlobalTransTarget(client);
+	ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Ability has cooldown", Ability_CD);
 }

--- a/addons/sourcemod/scripting/zombie_riot/npc/baka/npc_cybergrind_gm.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/baka/npc_cybergrind_gm.sp
@@ -1041,20 +1041,20 @@ static void CyberGrindGM_ClotThink(int iNPC)
 						NPCPritToChat(npc.index, "{slateblue}", "MrV Talk 12", false, false);
 					//Citizen_SpawnAtPoint("b");
 					//Citizen_SpawnAtPoint();
-					if(CyberGrind_Difficulty==4)
+					float SelfPos[3];
+					GetEntPropVector(npc.index, Prop_Data, "m_vecAbsOrigin", SelfPos);
+					float AllyAng[3];
+					GetEntPropVector(npc.index, Prop_Data, "m_angRotation", AllyAng);
+					int Spawner_entity = GetRandomActiveSpawner();
+					if(IsValidEntity(Spawner_entity))
 					{
-						float SelfPos[3];
-						GetEntPropVector(npc.index, Prop_Data, "m_vecAbsOrigin", SelfPos);
-						float AllyAng[3];
-						GetEntPropVector(npc.index, Prop_Data, "m_angRotation", AllyAng);
-						int Spawner_entity = GetRandomActiveSpawner();
-						if(IsValidEntity(Spawner_entity))
-						{
-							GetEntPropVector(Spawner_entity, Prop_Data, "m_vecOrigin", SelfPos);
-							GetEntPropVector(Spawner_entity, Prop_Data, "m_angRotation", AllyAng);
-						}
-						NPC_CreateByName("npc_invisible_trigger_man", -1, SelfPos, AllyAng, TFTeam_Stalkers, "cybergrind_ex_hard");
+						GetEntPropVector(Spawner_entity, Prop_Data, "m_vecOrigin", SelfPos);
+						GetEntPropVector(Spawner_entity, Prop_Data, "m_angRotation", AllyAng);
 					}
+					if(CyberGrind_Difficulty==4)
+						NPC_CreateByName("npc_invisible_trigger_man", -1, SelfPos, AllyAng, TFTeam_Stalkers, "cybergrind_ex_hard");
+					else
+						NPC_CreateByName("npc_invisible_trigger_man", -1, SelfPos, AllyAng, TFTeam_Stalkers, "fast_building_cooldown");
 					Spawn_Cured_Grigori();
 					//CyberGrindGM_Talk("Rebels Arrive", true);
 					/*if(CyberGrind_Difficulty!=4)

--- a/addons/sourcemod/scripting/zombie_riot/npc/baka/npc_invisible_trigger_man.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/baka/npc_invisible_trigger_man.sp
@@ -309,7 +309,7 @@ static void Cybergrind_EX_Hard_Mode_ClotThink(int iNPC)
 		return;
 	npc.m_flNextThinkTime = gameTime + 0.1;
 	
-	if(!Waves_Started() && Waves_InSetup())
+	if(!(Waves_Started() && !Waves_InSetup()))
 	{
 		for(int client = 1; client <= MaxClients; client++)
 		{
@@ -1157,14 +1157,14 @@ static void Invisible_TRIGGER_Man_ClotThink(int iNPC)
 				}
 			}
 
-			if(npc.m_flCoolDown && npc.m_flCoolDown < gameTime)
+			/*if(npc.m_flCoolDown && npc.m_flCoolDown < gameTime)
 			{
 				b_NpcForcepowerupspawn[npc.index] = 0;
 				i_RaidGrantExtra[npc.index] = 0;
 				b_DissapearOnDeath[npc.index] = true;
 				b_DoGibThisNpc[npc.index] = true;
 				SmiteNpcToDeath(npc.index);
-			}
+			}*/
 		} 
 	}
 	

--- a/addons/sourcemod/scripting/zombie_riot/object/obj_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/object/obj_barracks.sp
@@ -964,10 +964,12 @@ void Barracks_BuildingThink(int entity)
 	}
 	
 	int client = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
-	npc.m_flNextThinkTime = GameTime + (Store_HasNamedItem(client, "Modern Defense") ? 0.1 : 0.2);
-
 	if(!IsValidClient(client))
+	{
+		npc.m_flNextThinkTime = GameTime + 0.2;
 		return;
+	}
+	npc.m_flNextThinkTime = GameTime + (Store_HasNamedItem(client, "Modern Defense") ? 0.1 : 0.2);
 	
 	if(GetTeam(client) != 2)
 		return;

--- a/addons/sourcemod/scripting/zombie_riot/random_pickups.sp
+++ b/addons/sourcemod/scripting/zombie_riot/random_pickups.sp
@@ -66,7 +66,7 @@ public Action RandomPickup_DelayBetweenSpawns(Handle timer)
 	return Plugin_Continue;
 }
 
-bool RandomPickup_SpawnPickup(float VectorGoal[3])
+int RandomPickup_SpawnPickup(float VectorGoal[3])
 {
 	static float hullcheckmaxs_Player[3];
 	static float hullcheckmins_Player[3];
@@ -106,8 +106,9 @@ bool RandomPickup_SpawnPickup(float VectorGoal[3])
 			MaxPickups *= 2;
 		}
 		CreateTimer(RandomPickupTime * MaxPickups, Timer_RemoveEntity, EntIndexToEntRef(prop), TIMER_FLAG_NO_MAPCHANGE);
-	}	
-	return true;
+		return prop;
+	}
+	return -1;
 }
 
 public void RandomPickup_TouchPickup(int entity, int other)

--- a/addons/sourcemod/translations/zombieriot.phrases.foolishservers.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.foolishservers.txt
@@ -203,6 +203,8 @@
 	{
 		"en"	"You have cleared [EX Hard] Cyber ​​Grind!\nStart with extra 30 extra credits."
 		"ko"	"[EX Hard] 난이도의 사이버 그라인드를 클리어했습니다!\n시작 자금 +30"
+		//"en"	"When equipped, You get Silvester Wings..\nRemember. He watches."
+		//"ko"	"착용시, 실베스터의 날개를 얻습니다..\n기억하십시오. 그가 지켜보고 있습니다."
 	}
 	
 	//인벤토리 모듈
@@ -1067,18 +1069,8 @@
 	
 	"Custom Mini Semi Gun: Overheating FeedBack Desc"
 	{
-		"en"		"The longer you hold down fire, the more damage and tighter spread your weapon deals"
-		"ko"		"공격 버튼을 오래 누르고 있을수록, 이 무기의 피해량및 집탄율 증가"
-	}
-	"Custom Mini Semi Gun: Overheating FeedBack - Overclocking MAX"
-	{
-		"en"		"[Overclock MOD]\nMAX Overheat"
-		"ko"		"[과부하 모드]\n최대 과열 도달"
-	}
-	"Custom Mini Semi Gun: Overheating FeedBack - Overclocking Charge"
-	{
-		"en"		"[Overclock MOD]\nHeating up:"
-		"ko"		"[과부하 모드]\n예열중:"
+		"en"		"The longer you hold down fire, the more damage and tighter spread your weapon deals\nWhen used, if the maximum overheating value reaches 200%, damage is tripled according to the overheating value, and if the overheating is below 100%, the overheating value increases faster"
+		"ko"		"공격 버튼을 오래 누르고 있을수록, 이 무기의 피해량및 집탄율 증가\nM2: 사용 시, 사용 시, 최대 과열 수치 200%, 과열 수치에 따른 피해량 3배, 과열이 100％ 미만인 경우 과열 수치가 더 빨리 증가"
 	}
 	"Custom Mini Semi Gun: Overheating FeedBack - MAX"
 	{
@@ -1089,6 +1081,22 @@
 	{
 		"en"		"Heating up:"
 		"ko"		"예열 중:"
+	}
+	"Custom Mini Semi Gun: Overheating FeedBack - Overclocking"
+	{
+		"en"		"[Overclock MOD]"
+		"ko"		"[과부하 모드]"
+	}
+	"Custom Mini Semi Gun: Overheating FeedBack - Meltdown in"
+	{
+		"#format"	"{1:d}"
+		"en"		"Meltdown in T-{1}s"
+		"ko"		"멜트다운까지 {1}초 남음"
+	}
+	"Custom Mini Semi Gun: Overheating FeedBack - Fully Meltdown"
+	{
+		"en"		"Fully Meltdown...: [DMG, ATK DOWN]"
+		"ko"		"멜트 다운...: [피해량, 공속 감소]"
 	}
 	"Custom Mini Semi Gun: Bullet Storm Desc"
 	{


### PR DESCRIPTION
# 무기
## 기관단총 - 미니 세미 건 - 괴열 피드백:
\- 최대 과열을 11.75초 동안 유지하면 패널티를 받음
\- 패널티: 과열 피해량 배수 0.5, 공속 35％ 감소
\-  패널티는 공격을 멈춰야 초기화됨
\+ M2 쿨다운 60초 -> 45초
\= 최대 과열 유지 시간은 장탄수에 영향을 받음(압탄을 사면 14.68초가 됨)
\= 누락된 M2 설명 추가

## 엘리트 스나이퍼 - 물품 드롭:
\- M2 제거
\+ 패시브 추가:
├ + 자동으로 무작위 적에게 마킹을 적용함.
├ + 마킹된 적은 외곽선이 노출되며, 처치시 무작위 만파워를 드롭함(냉동 폭탄, 슈퍼 할인 제외)
├ = 적이 없다면 5초의 쿨다운이 적용됨
├ - 레이드 보스, 슈퍼 보스, 무적, 타겟 불가, 특수 NPC 테그를 가진 대상 에겐 적용되지않음.
├ - 한 웨이브에 한번만 사용됨.
└ - 쿨다운 90초
R 추가:
├ + 1번(막팹시 2번) 사용할수있는 (십자군 쇠뇌랑 동작이 비슷함), 사거리는 무제한, 착탄 지점에 팩을 스폰시킴
├ + 팩을 흭득한 아군에게 체력. 아머 회복 및 탄약과 금속이 추가되고 잠시 이속증진을 얻음.
└ - 쿨다운 60초
+ 명사수 맥주 사용중 적에게 헤드샷 성공시, 능력 쿨다운 감소

## 메디건 - 적응형:
= 앉아서 R키로 피해, 치유 유형을 변경할수 없던 문제 수정

# ETC
## 싸이버 그라인드:
준비 시간동안 구조물 쿨다운 감소가 적용  되지않던 문제 수정

## 인벤 - 바리케이드 안정화 장치:
등에 맨 구조물이 받는 피해 50％ 감소
폭발 드럼통을 등애 매면 내구도를 표시하지않던 문제 수정