### PR TITLE
Overheating FeedBack Nerf

### DIFF
--- a/addons/sourcemod/scripting/zombie_riot/custom/addons/weapon_mini_semi_gun.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/addons/weapon_mini_semi_gun.sp
@@ -145,7 +145,7 @@ public void Weapon_Mini_Semi_Gun_OverheatingFeedBack_M1(int client, int weapon, 
 	OverheatingFeedBack_RestTime[client] = GameTime + Attributes_Get(weapon, 6, 0.25) *0.4;
 	if(OverheatingFeedBack_FullMeltdown[client])
 		Ratio*=0.5;
-	Attributes_Set(weapon, 1, Ratio+1.0);
+	Attributes_Set(weapon, 1, (Ratio*0.5)+1.0);
 	float spread = 0.7-(0.35*Ratio);
 	if(spread < 0.3)spread = 0.3;
 	Attributes_Set(weapon, 106, spread);


### PR DESCRIPTION
# 기관단총 - 미니 세미 건 - 괴열 피드백:
## 과열 배율 너프
\- 최대 과열시 피해량 2배 -> 1.5배
\- 과부하 모드 최대 과열시 피해량 3배 -> 2배