### PR TITLE
Leak

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -1380,7 +1380,7 @@
 				
 				"pap_7_classname"						"tf_weapon_smg"
 				"pap_7_index"							"211"
-				"pap_7_attributes"						"45 ; 2 ; 2 ; 40.1 ; 6 ; 0.85 ; 303 ; -1 ; 106 ; 0.7 ; 4 ; 1.0 ; 1 ; 1.0 ; 5 ; 1.0 ; 834 ; 420"
+				"pap_7_attributes"						"45 ; 2 ; 2 ; 32.5 ; 6 ; 0.85 ; 303 ; -1 ; 106 ; 0.7 ; 4 ; 1.0 ; 1 ; 1.0 ; 5 ; 1.0 ; 834 ; 420"
 				"pap_7_ammo"							"18"
 				
 				"pap_7_weapon_archetype"				"4"
@@ -18735,7 +18735,7 @@
 					"pap_3_desc"							"Custom Barracks Kit: The CastleSiege Desc New Trick"
 					"pap_3_classname"						"tf_weapon_smg"
 					"pap_3_index"							"751"
-					"pap_2_attributes"						"2 ; 40.12 ; 6 ; 0.94 ; 4 ; 1.5 ; 106 ; 0.6 ; 97 ; 1.4"
+					"pap_3_attributes"						"2 ; 40.12 ; 6 ; 0.94 ; 4 ; 1.5 ; 106 ; 0.6 ; 97 ; 1.4"
 					"pap_3_ammo"							"19"
 					"pap_3_ignore_upgrades"					"1"
 					
@@ -18777,7 +18777,7 @@
 					"pap_5_ammo"							"19"
 					"pap_5_ignore_upgrades"					"1"
 					
-					"pap_7_func_weaponcreated"				"Enable_CastleSiege"	
+					"pap_5_func_weaponcreated"				"Enable_CastleSiege"	
 					"pap_5_func_ontakedamage_deal"			"Barracks_OnTakeDamage_CastleSiege"
 					"pap_5_func_attack2"   					"Weapon_CastleSiege_M2"
 					"pap_5_func_attack3"					"Barracks_CastleSiegeMode"
@@ -18859,10 +18859,11 @@
 					"desc"									"Reconstructive Shotgun Desc"
 					"classname"								"tf_weapon_shotgun_primary"
 					"index"									"527"
-					"attributes"							"2 ; 4.2 ; 5 ; 1.5 ; 303 ; -1 ; 4 ; 0.3 ; 106 ; 0.5"
+					"attributes"							"2 ; 4.2 ; 5 ; 1.5 ; 303 ; -1 ; 4 ; 0.3 ; 106 ; 0.5 ; 45 ; 1.0"
 					"ammo"									"19"
 					"ignore_upgrades"						"1"
 					
+					"func_weaponcreated"					"Enable_Barracks_Hunter"
 					"func_ontakedamage_deal"				"Barracks_OnTakeDamage_Hunter"
 					"func_attack2"   						"Weapon_Hunter_M2"
 
@@ -18876,10 +18877,11 @@
 					"pap_1_desc"							"Reconstructive Shotgun Desc 1"
 					"pap_1_classname"						"tf_weapon_shotgun_primary"
 					"pap_1_index"							"527"
-					"pap_1_attributes"						"2 ; 7.6 ; 5 ; 1.4 ; 303 ; -1 ; 4 ; 0.5 ; 106 ; 0.5"
+					"pap_1_attributes"						"2 ; 7.6 ; 5 ; 1.4 ; 303 ; -1 ; 4 ; 0.5 ; 106 ; 0.5 ; 45 ; 1.0"
 					"pap_1_ammo"							"19"
 					"pap_1_ignore_upgrades"					"1"
 					
+					"pap_1_func_weaponcreated"				"Enable_Barracks_Hunter"
 					"pap_1_func_ontakedamage_deal"			"Barracks_OnTakeDamage_Hunter"
 					"pap_1_func_attack2"   					"Weapon_Hunter_M2"
 					
@@ -18893,10 +18895,11 @@
 					"pap_2_desc"							"Reconstructive Shotgun Desc 2"
 					"pap_2_classname"						"tf_weapon_shotgun_primary"
 					"pap_2_index"							"527"
-					"pap_2_attributes"						"2 ; 12.0 ; 5 ; 1.3 ; 303 ; -1 ; 4 ; 0.6 ; 106 ; 0.5"
+					"pap_2_attributes"						"2 ; 12.0 ; 5 ; 1.3 ; 303 ; -1 ; 4 ; 0.6 ; 106 ; 0.5 ; 45 ; 1.0"
 					"pap_2_ammo"							"19"
 					"pap_2_ignore_upgrades"					"1"
 					
+					"pap_2_func_weaponcreated"				"Enable_Barracks_Hunter"
 					"pap_2_func_ontakedamage_deal"			"Barracks_OnTakeDamage_Hunter"
 					"pap_2_func_attack2"   					"Weapon_Hunter_M2"
 					
@@ -18910,10 +18913,11 @@
 					"pap_3_desc"							"Reconstructive Shotgun Desc 3"
 					"pap_3_classname"						"tf_weapon_shotgun_primary"
 					"pap_3_index"							"527"
-					"pap_3_attributes"						"2 ; 18.0 ; 5 ; 1.3 ; 303 ; -1 ; 4 ; 0.8 ; 106 ; 0.5"
+					"pap_3_attributes"						"2 ; 18.0 ; 5 ; 1.3 ; 303 ; -1 ; 4 ; 0.8 ; 106 ; 0.5 ; 45 ; 1.0"
 					"pap_3_ammo"							"19"
 					"pap_3_ignore_upgrades"					"1"
 					
+					"pap_3_func_weaponcreated"				"Enable_Barracks_Hunter"
 					"pap_3_func_ontakedamage_deal"			"Barracks_OnTakeDamage_Hunter"
 					"pap_3_func_attack2"   					"Weapon_Hunter_M2"
 					"pap_3_func_attack3"					"Barracks_ChangeBuffMode"
@@ -18928,10 +18932,11 @@
 					"pap_4_desc"							"Reconstructive Shotgun Desc 4"
 					"pap_4_classname"						"tf_weapon_shotgun_primary"
 					"pap_4_index"							"527"
-					"pap_4_attributes"						"2 ; 35.0 ; 5 ; 1.3 ; 303 ; -1 ; 4 ; 1.0 ; 106 ; 0.5"
+					"pap_4_attributes"						"2 ; 35.0 ; 5 ; 1.3 ; 303 ; -1 ; 4 ; 1.0 ; 106 ; 0.5 ; 45 ; 1.0"
 					"pap_4_ammo"							"19"
 					"pap_4_ignore_upgrades"					"1"
 					
+					"pap_4_func_weaponcreated"				"Enable_Barracks_Hunter"
 					"pap_4_func_ontakedamage_deal"			"Barracks_OnTakeDamage_Hunter"
 					"pap_4_func_attack2"   					"Weapon_Hunter_M2"
 					"pap_4_func_attack3"					"Barracks_ChangeBuffMode"
@@ -18946,10 +18951,11 @@
 					"pap_5_desc"							"Reconstructive Shotgun Desc 5"
 					"pap_5_classname"						"tf_weapon_shotgun_primary"
 					"pap_5_index"							"527"
-					"pap_5_attributes"						"2 ; 70.0 ; 5 ; 1.3 ; 303 ; -1 ; 4 ; 1.2 ; 106 ; 0.5"
+					"pap_5_attributes"						"2 ; 70.0 ; 5 ; 1.3 ; 303 ; -1 ; 4 ; 1.2 ; 106 ; 0.5 ; 45 ; 1.0"
 					"pap_5_ammo"							"19"
 					"pap_5_ignore_upgrades"					"1"
 					
+					"pap_5_func_weaponcreated"				"Enable_Barracks_Hunter"
 					"pap_5_func_ontakedamage_deal"			"Barracks_OnTakeDamage_Hunter"
 					"pap_5_func_attack2"   					"Weapon_Hunter_M2"
 					"pap_5_func_attack3"					"Barracks_ChangeBuffMode"
@@ -18964,10 +18970,11 @@
 					"pap_6_desc"							"Reconstructive Shotgun Desc 6"
 					"pap_6_classname"						"tf_weapon_shotgun_primary"
 					"pap_6_index"							"527"
-					"pap_6_attributes"						"2 ; 120.0 ; 5 ; 1.2 ; 303 ; -1 ; 4 ; 1.4 ; 106 ; 0.5"
+					"pap_6_attributes"						"2 ; 120.0 ; 5 ; 1.2 ; 303 ; -1 ; 4 ; 1.4 ; 106 ; 0.5 ; 45 ; 1.0"
 					"pap_6_ammo"							"19"
 					"pap_6_ignore_upgrades"					"1"
 
+					"pap_6_func_weaponcreated"				"Enable_Barracks_Hunter"
 					"pap_6_func_ontakedamage_deal"			"Barracks_OnTakeDamage_Hunter"
 					"pap_6_func_attack2"   					"Weapon_Hunter_M2"
 					"pap_6_func_attack3"					"Barracks_ChangeBuffMode"
@@ -18982,10 +18989,11 @@
 					"pap_7_desc"							"Reconstructive Shotgun Desc 7"
 					"pap_7_classname"						"tf_weapon_shotgun_primary"
 					"pap_7_index"							"527"
-					"pap_7_attributes"						"2 ; 200.0 ; 5 ; 1.2 ; 303 ; -1 ; 4 ; 1.4 ; 106 ; 0.5"
+					"pap_7_attributes"						"2 ; 200.0 ; 5 ; 1.2 ; 303 ; -1 ; 4 ; 1.4 ; 106 ; 0.5 ; 45 ; 1.0"
 					"pap_7_ammo"							"19"
 					"pap_7_ignore_upgrades"					"1"
 					
+					"pap_7_func_weaponcreated"				"Enable_Barracks_Hunter"
 					"pap_7_func_ontakedamage_deal"			"Barracks_OnTakeDamage_Hunter"
 					"pap_7_func_attack2"   					"Weapon_Hunter_M2"
 					"pap_7_func_attack3"					"Barracks_ChangeBuffMode"


### PR DESCRIPTION
누락된 샷건 커맨더킷 펑션 추가

미니 세미 건 - 과열 피드백:
\- 베이스 피해량 35.5 -> 26.5 으로 감소