### PR TITLE
Need Barracks

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -18504,163 +18504,6 @@
 				"pap_6_func_onunequip"	"CommanderKit_Unequip"
 				"pap_7_func_onunequip"	"CommanderKit_Unequip"
 				
-				"The Marker"
-				{
-					"cost"				"0"
-					"pap_1_cost"		"1800"
-					"pap_2_cost"		"3750"
-					"pap_3_cost"		"12000"
-					"pap_4_cost"		"23000"
-					"pap_5_cost"		"7500"
-					"pap_6_cost"		"16200"
-					"pap_7_cost"		"50000"
-
-					"desc"									"The Marker Desc"
-					"classname"								"tf_weapon_revolver"
-					"index"									"161"
-					"attributes"							"2 ; 1.8 ; 5 ; 1.5 ; 97 ; 1.5 ; 4 ; 0.3 ; 106 ; 0.5 ; 868 ; 0 ; 4050 ; 1"
-					"ammo"									"19"
-					"ignore_upgrades"						"1"
-
-					"func_weaponcreated"					"Enable_Barracks"	
-					"func_mapstart"							"Barracks_OnMapStart"	
-					
-					"func_ontakedamage_deal"				"Barracks_OnTakeDamage"
-					"func_attack2"   						"Weapon_Marker_M2"
-
-					"lag_comp"								"1"
-					"lag_comp_collision"					"0"
-					"lag_comp_extend_boundingbox"			"1"
-					"lag_comp_dont_move_building" 			"0"
-					"weapon_archetype"						"20"
-					"viewmodel_force_class"					"8" //8 is pie (spy)
-					
-					"pap_1_desc"							"The Marker Desc 1"
-					"pap_1_classname"						"tf_weapon_revolver"
-					"pap_1_index"							"161"
-					"pap_1_attributes"						"2 ; 4.2 ; 5 ; 1.4 ; 97 ; 1.4 ; 4 ; 0.5 ; 106 ; 0.5 ; 868 ; 1 ; 26 ; 50; 4050 ; 4"
-					"pap_1_ammo"	"19"
-					"pap_1_ignore_upgrades"					"1"
-					
-					"pap_1_func_weaponcreated"				"Enable_Barracks"	
-					"pap_1_func_ontakedamage_deal"			"Barracks_OnTakeDamage"
-					"pap_1_func_attack2"   					"Weapon_Marker_M2"
-					
-					"pap_1_lag_comp"						"1"
-					"pap_1_lag_comp_collision"				"0"
-					"pap_1_lag_comp_extend_boundingbox"		"1"
-					"pap_1_lag_comp_dont_move_building" 	"0"
-					"pap_1_weapon_archetype"				"20"
-					"pap_1_viewmodel_force_class"			"8" //8 is pie (spy)
-					
-					"pap_2_desc"							"The Marker Desc 2"
-					"pap_2_classname"						"tf_weapon_revolver"
-					"pap_2_index"							"161"
-					"pap_2_attributes"						"2 ; 7.0 ; 5 ; 1.3 ; 97 ; 1.3 ; 4 ; 0.6 ; 106 ; 0.5 ; 868 ; 2 ; 26 ; 100; 4050 ; 8"
-					"pap_2_ammo"	"19"
-					"pap_2_ignore_upgrades"					"1"
-					
-					"pap_2_func_weaponcreated"				"Enable_Barracks"	
-					"pap_2_func_ontakedamage_deal"			"Barracks_OnTakeDamage"
-					"pap_2_func_attack2"   					"Weapon_Marker_M2"
-					
-					"pap_2_lag_comp"						"1"
-					"pap_2_lag_comp_collision"				"0"
-					"pap_2_lag_comp_extend_boundingbox"		"1"
-					"pap_2_lag_comp_dont_move_building" 	"0"
-					"pap_2_weapon_archetype"				"20"
-					"pap_2_viewmodel_force_class"			"8" //8 is pie (spy)
-					
-					"pap_3_desc"							"The Marker Desc 3"
-					"pap_3_classname"						"tf_weapon_revolver"
-					"pap_3_index"							"161"
-					"pap_3_attributes"						"2 ; 13.0 ; 5 ; 1.2 ; 97 ; 1.2 ; 4 ; 0.8 ; 106 ; 0.5 ; 868 ; 3 ; 26 ; 150; 4050 ; 11"
-					"pap_3_ammo"	"19"
-					"pap_3_ignore_upgrades"					"1"
-					
-					"pap_3_func_weaponcreated"				"Enable_Barracks"	
-					"pap_3_func_ontakedamage_deal"			"Barracks_OnTakeDamage"
-					"pap_3_func_attack2"   					"Weapon_Marker_M2"
-					
-					"pap_3_lag_comp"						"1"
-					"pap_3_lag_comp_collision"				"0"
-					"pap_3_lag_comp_extend_boundingbox"		"1"
-					"pap_3_lag_comp_dont_move_building" 	"0"
-					"pap_3_weapon_archetype"				"20"
-					"pap_3_viewmodel_force_class"			"8" //8 is pie (spy)
-					
-					"pap_4_desc"							"The Marker Desc 4"
-					"pap_4_classname"						"tf_weapon_revolver"
-					"pap_4_index"							"161"
-					"pap_4_attributes"						"2 ; 27.0 ; 5 ; 1.1 ; 97 ; 1.1 ; 4 ; 1.0 ; 106 ; 0.5 ; 868 ; 4 ; 26 ; 250; 4050 ; 14"
-					"pap_4_ammo"	"19"
-					"pap_4_ignore_upgrades"					"1"
-					
-					"pap_4_func_weaponcreated"				"Enable_Barracks"	
-					"pap_4_func_ontakedamage_deal"			"Barracks_OnTakeDamage"
-					"pap_4_func_attack2"   					"Weapon_Marker_M2"
-					
-					"pap_4_lag_comp"						"1"
-					"pap_4_lag_comp_collision"				"0"
-					"pap_4_lag_comp_extend_boundingbox"		"1"
-					"pap_4_lag_comp_dont_move_building" 	"0"
-					"pap_4_weapon_archetype"				"20"
-					"pap_4_viewmodel_force_class"			"8" //8 is pie (spy)
-					
-					"pap_5_desc"							"The Marker Desc 5"
-					"pap_5_classname"						"tf_weapon_revolver"
-					"pap_5_index"							"161"
-					"pap_5_attributes"						"2 ; 55.0 ; 5 ; 1.0 ; 97 ; 1.0 ; 4 ; 1.0 ; 106 ; 0.5 ; 868 ; 5 ; 26 ; 400; 4050 ; 18"
-					"pap_5_ammo"	"19"
-					"pap_5_ignore_upgrades"					"1"
-					
-					"pap_5_func_weaponcreated"				"Enable_Barracks"	
-					"pap_5_func_ontakedamage_deal"			"Barracks_OnTakeDamage"
-					"pap_5_func_attack2"   					"Weapon_Marker_M2"
-					
-					"pap_5_lag_comp"						"1"
-					"pap_5_lag_comp_collision"				"0"
-					"pap_5_lag_comp_extend_boundingbox"		"1"
-					"pap_5_lag_comp_dont_move_building" 	"0"
-					"pap_5_weapon_archetype"				"20"
-					"pap_5_viewmodel_force_class"			"8" //8 is pie (spy)
-					
-					"pap_6_desc"							"The Marker Desc 6"
-					"pap_6_classname"						"tf_weapon_revolver"
-					"pap_6_index"							"161"
-					"pap_6_attributes"						"2 ; 100.0 ; 5 ; 0.9 ; 97 ; 0.9 ; 4 ; 1.0 ; 106 ; 0.5 ; 868 ; 6 ; 26 ; 500; 4050 ; 24"
-					"pap_6_ammo"	"19"
-					"pap_6_ignore_upgrades"					"1"
-					
-					"pap_6_func_weaponcreated"				"Enable_Barracks"	
-					"pap_6_func_ontakedamage_deal"			"Barracks_OnTakeDamage"
-					"pap_6_func_attack2"   					"Weapon_Marker_M2"
-					
-					"pap_6_lag_comp"						"1"
-					"pap_6_lag_comp_collision"				"0"
-					"pap_6_lag_comp_extend_boundingbox"		"1"
-					"pap_6_lag_comp_dont_move_building" 	"0"
-					"pap_6_weapon_archetype"				"20"
-					"pap_6_viewmodel_force_class"			"8" //8 is pie (spy)
-					
-					"pap_7_desc"							"The Marker Desc 7"
-					"pap_7_classname"						"tf_weapon_revolver"
-					"pap_7_index"							"161"
-					"pap_7_attributes"						"2 ; 150.0 ; 5 ; 0.8 ; 97 ; 0.8 ; 4 ; 1.0 ; 106 ; 0.5 ; 868 ; 7 ; 26 ; 750; 4050 ; 26"
-					"pap_7_ammo"	"19"
-					"pap_7_ignore_upgrades"					"1"
-					
-					"pap_7_func_weaponcreated"				"Enable_Barracks"	
-					"pap_7_func_ontakedamage_deal"			"Barracks_OnTakeDamage"
-					"pap_7_func_attack2"   					"Weapon_Marker_M2"
-					
-					"pap_7_lag_comp"						"1"
-					"pap_7_lag_comp_collision"				"0"
-					"pap_7_lag_comp_extend_boundingbox"		"1"
-					"pap_7_lag_comp_dont_move_building" 	"0"
-					"pap_7_weapon_archetype"				"20"
-					"pap_7_viewmodel_force_class"			"8" //8 is pie (spy)
-				}
 				"Custom Barracks Kit: The CastleSiege"
 				{
 					"cost"				"0"
@@ -18685,11 +18528,12 @@
 					"classname"								"tf_weapon_smg"
 					"ammo"									"19"
 					"index"									"751"
-					"attributes"							"2 ; 4.0 ; 6 ; 1.0 ; 4 ; 1.0 ; 106 ; 0.6 ; 97 ; 1.6"
+					"attributes"							"2 ; 4.0 ; 6 ; 1.0 ; 4 ; 1.0 ; 106 ; 0.6 ; 97 ; 1.6 ; 868 ; 0 ; 4050 ; 1"
 					"ignore_upgrades"						"1"	
 					
+					"func_weaponcreated"					"Enable_CastleSiege"
 					"func_ontakedamage_deal"				"Barracks_OnTakeDamage_CastleSiege"
-					"func_attack2"   						"Weapon_CastleSiege_M2"
+					"func_attack2"							"Barracks_CastleSiegeMode"
 
 					"lag_comp"								"1"
 					"lag_comp_collision"					"0"
@@ -18701,12 +18545,13 @@
 					"pap_1_desc"							"Custom Barracks Kit: The CastleSiege Desc Default"
 					"pap_1_classname"						"tf_weapon_smg"
 					"pap_1_index"							"751"
-					"pap_1_attributes"						"2 ; 10.32 ; 6 ; 1.0 ; 4 ; 1.2 ; 106 ; 0.6 ; 97 ; 1.55"
+					"pap_1_attributes"						"2 ; 10.32 ; 6 ; 1.0 ; 4 ; 1.2 ; 106 ; 0.6 ; 97 ; 1.55 ; 868 ; 1 ; 26 ; 50; 4050 ; 4"
 					"pap_1_ammo"							"19"
 					"pap_1_ignore_upgrades"					"1"
 					
+					"pap_1_func_weaponcreated"				"Enable_CastleSiege"
 					"pap_1_func_ontakedamage_deal"			"Barracks_OnTakeDamage_CastleSiege"
-					"pap_1_func_attack2"   					"Weapon_CastleSiege_M2"
+					"pap_1_func_attack2"					"Barracks_CastleSiegeMode"
 					
 					"pap_1_lag_comp"						"1"
 					"pap_1_lag_comp_collision"				"0"
@@ -18718,12 +18563,13 @@
 					"pap_2_desc"							"Custom Barracks Kit: The CastleSiege Desc Default"
 					"pap_2_classname"						"tf_weapon_smg"
 					"pap_2_index"							"751"
-					"pap_2_attributes"						"2 ; 21.1 ; 6 ; 0.96 ; 4 ; 1.35 ; 106 ; 0.6 ; 97 ; 1.5"
+					"pap_2_attributes"						"2 ; 21.1 ; 6 ; 0.96 ; 4 ; 1.35 ; 106 ; 0.6 ; 97 ; 1.5 ; 868 ; 2 ; 26 ; 100; 4050 ; 8"
 					"pap_2_ammo"							"19"
 					"pap_2_ignore_upgrades"					"1"
 					
+					"pap_2_func_weaponcreated"				"Enable_CastleSiege"
 					"pap_2_func_ontakedamage_deal"			"Barracks_OnTakeDamage_CastleSiege"
-					"pap_2_func_attack2"   					"Weapon_CastleSiege_M2"
+					"pap_2_func_attack2"					"Barracks_CastleSiegeMode"
 					
 					"pap_2_lag_comp"						"1"
 					"pap_2_lag_comp_collision"				"0"
@@ -18735,14 +18581,13 @@
 					"pap_3_desc"							"Custom Barracks Kit: The CastleSiege Desc New Trick"
 					"pap_3_classname"						"tf_weapon_smg"
 					"pap_3_index"							"751"
-					"pap_3_attributes"						"2 ; 40.12 ; 6 ; 0.94 ; 4 ; 1.5 ; 106 ; 0.6 ; 97 ; 1.4"
+					"pap_3_attributes"						"2 ; 40.12 ; 6 ; 0.94 ; 4 ; 1.5 ; 106 ; 0.6 ; 97 ; 1.4 ; 868 ; 3 ; 26 ; 150; 4050 ; 11"
 					"pap_3_ammo"							"19"
 					"pap_3_ignore_upgrades"					"1"
 					
 					"pap_3_func_weaponcreated"				"Enable_CastleSiege"	
 					"pap_3_func_ontakedamage_deal"			"Barracks_OnTakeDamage_CastleSiege"
-					"pap_3_func_attack2"   					"Weapon_CastleSiege_M2"
-					"pap_3_func_attack3"					"Barracks_CastleSiegeMode"
+					"pap_3_func_attack2"   					"Barracks_CastleSiegeMode"
 					
 					"pap_3_lag_comp"						"1"
 					"pap_3_lag_comp_collision"				"0"
@@ -18754,14 +18599,13 @@
 					"pap_4_desc"							"Custom Barracks Kit: The CastleSiege Desc Default"
 					"pap_4_classname"						"tf_weapon_smg"
 					"pap_4_index"							"751"
-					"pap_4_attributes"						"2 ; 84.66 ; 6 ; 0.9 ; 4 ; 1.5 ; 106 ; 0.6 ; 97 ; 1.35"
+					"pap_4_attributes"						"2 ; 84.66 ; 6 ; 0.9 ; 4 ; 1.5 ; 106 ; 0.6 ; 97 ; 1.35 ; 868 ; 4 ; 26 ; 250; 4050 ; 14"
 					"pap_4_ammo"							"19"
 					"pap_4_ignore_upgrades"					"1"
 					
 					"pap_4_func_weaponcreated"				"Enable_CastleSiege"	
 					"pap_4_func_ontakedamage_deal"			"Barracks_OnTakeDamage_CastleSiege"
-					"pap_4_func_attack2"   					"Weapon_CastleSiege_M2"
-					"pap_4_func_attack3"					"Barracks_CastleSiegeMode"
+					"pap_4_func_attack2"   					"Barracks_CastleSiegeMode"
 					
 					"pap_4_lag_comp"						"1"
 					"pap_4_lag_comp_collision"				"0"
@@ -18773,14 +18617,13 @@
 					"pap_5_desc"							"Custom Barracks Kit: The CastleSiege Desc Default"
 					"pap_5_classname"						"tf_weapon_smg"
 					"pap_5_index"							"751"
-					"pap_5_attributes"						"2 ; 223.52 ; 6 ; 0.9 ; 4 ; 1.5 ; 106 ; 0.6 ; 97 ; 1.3"
+					"pap_5_attributes"						"2 ; 223.52 ; 6 ; 0.9 ; 4 ; 1.5 ; 106 ; 0.6 ; 97 ; 1.3 ; 868 ; 5 ; 26 ; 400; 4050 ; 18"
 					"pap_5_ammo"							"19"
 					"pap_5_ignore_upgrades"					"1"
 					
 					"pap_5_func_weaponcreated"				"Enable_CastleSiege"	
 					"pap_5_func_ontakedamage_deal"			"Barracks_OnTakeDamage_CastleSiege"
-					"pap_5_func_attack2"   					"Weapon_CastleSiege_M2"
-					"pap_5_func_attack3"					"Barracks_CastleSiegeMode"
+					"pap_5_func_attack2"   					"Barracks_CastleSiegeMode"
 					
 					"pap_5_lag_comp"						"1"
 					"pap_5_lag_comp_collision"				"0"
@@ -18792,14 +18635,13 @@
 					"pap_6_desc"							"Custom Barracks Kit: The CastleSiege Desc Default"
 					"pap_6_classname"						"tf_weapon_smg"
 					"pap_6_index"							"751"
-					"pap_6_attributes"						"2 ; 368.8 ; 6 ; 0.87 ; 4 ; 1.65 ; 106 ; 0.6 ; 97 ; 1.2"
+					"pap_6_attributes"						"2 ; 368.8 ; 6 ; 0.87 ; 4 ; 1.65 ; 106 ; 0.6 ; 97 ; 1.2 ; 868 ; 6 ; 26 ; 500; 4050 ; 24"
 					"pap_6_ammo"							"19"
 					"pap_6_ignore_upgrades"					"1"
 					
 					"pap_6_func_weaponcreated"				"Enable_CastleSiege"	
 					"pap_6_func_ontakedamage_deal"			"Barracks_OnTakeDamage_CastleSiege"
-					"pap_6_func_attack2"   					"Weapon_CastleSiege_M2"
-					"pap_6_func_attack3"					"Barracks_CastleSiegeMode"
+					"pap_6_func_attack2"   					"Barracks_CastleSiegeMode"
 					
 					"pap_6_lag_comp"						"1"
 					"pap_6_lag_comp_collision"				"0"
@@ -18811,14 +18653,13 @@
 					"pap_7_desc"							"Custom Barracks Kit: The CastleSiege Desc Default"
 					"pap_7_classname"						"tf_weapon_smg"
 					"pap_7_index"							"751"
-					"pap_7_attributes"						"2 ; 627.0 ; 6 ; 0.85 ; 4 ; 1.7 ; 106 ; 0.6 ; 97 ; 1.0"
+					"pap_7_attributes"						"2 ; 627.0 ; 6 ; 0.85 ; 4 ; 1.7 ; 106 ; 0.6 ; 97 ; 1.0 ; 868 ; 7 ; 26 ; 750; 4050 ; 26"
 					"pap_7_ammo"							"19"
 					"pap_7_ignore_upgrades"					"1"
 					
 					"pap_7_func_weaponcreated"				"Enable_CastleSiege"	
 					"pap_7_func_ontakedamage_deal"			"Barracks_OnTakeDamage_CastleSiege"
-					"pap_7_func_attack2"   					"Weapon_CastleSiege_M2"
-					"pap_7_func_attack3"					"Barracks_CastleSiegeMode"
+					"pap_7_func_attack2"   					"Barracks_CastleSiegeMode"
 					
 					"pap_7_lag_comp"						"1"
 					"pap_7_lag_comp_collision"				"0"
@@ -18865,7 +18706,6 @@
 					
 					"func_weaponcreated"					"Enable_Barracks_Hunter"
 					"func_ontakedamage_deal"				"Barracks_OnTakeDamage_Hunter"
-					"func_attack2"   						"Weapon_Hunter_M2"
 
 					"lag_comp"								"1"
 					"lag_comp_collision"					"0"
@@ -18883,7 +18723,6 @@
 					
 					"pap_1_func_weaponcreated"				"Enable_Barracks_Hunter"
 					"pap_1_func_ontakedamage_deal"			"Barracks_OnTakeDamage_Hunter"
-					"pap_1_func_attack2"   					"Weapon_Hunter_M2"
 					
 					"pap_1_lag_comp"						"1"
 					"pap_1_lag_comp_collision"				"0"
@@ -18901,7 +18740,6 @@
 					
 					"pap_2_func_weaponcreated"				"Enable_Barracks_Hunter"
 					"pap_2_func_ontakedamage_deal"			"Barracks_OnTakeDamage_Hunter"
-					"pap_2_func_attack2"   					"Weapon_Hunter_M2"
 					
 					"pap_2_lag_comp"						"1"
 					"pap_2_lag_comp_collision"				"0"
@@ -18920,7 +18758,6 @@
 					"pap_3_func_weaponcreated"				"Enable_Barracks_Hunter"
 					"pap_3_func_ontakedamage_deal"			"Barracks_OnTakeDamage_Hunter"
 					"pap_3_func_attack2"   					"Weapon_Hunter_M2"
-					"pap_3_func_attack3"					"Barracks_ChangeBuffMode"
 					
 					"pap_3_lag_comp"						"1"
 					"pap_3_lag_comp_collision"				"0"

--- a/addons/sourcemod/scripting/shared/sdkhooks.sp
+++ b/addons/sourcemod/scripting/shared/sdkhooks.sp
@@ -3024,7 +3024,7 @@ void ApplyLastmanOrDyingOverlay(int client)
 	{
 		switch(Yakuza_Lastman())
 		{
-			case 1,2,3,4,7,9, 15:
+			case 1,2,3,4,7,9,15,17:
 			{
 				return;
 			}
@@ -3043,6 +3043,11 @@ void ApplyLastmanOrDyingOverlay(int client)
 			case 18:
 			{
 				if(Gunsaw_IsMerc(client) && f_OneShotProtectionTimer[client] < GetGameTime())
+					return;
+			}
+			default:
+			{
+				if(Weapon_AddonsOverlayForLastMan(client, Yakuza_Lastman()))
 					return;
 			}
 		}

--- a/addons/sourcemod/scripting/zombie_riot/custom/addons/cw_base.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/addons/cw_base.sp
@@ -38,6 +38,8 @@ stock void Weapon_AddonsCustomLastMan(int client)
 		CPrintToChatAll("{blue}Diabolus Ex Machina", client);
 		Yakuza_Lastman(13);
 	}*/
+	if(IsBarracks(client))
+		Barracks_OnLastManStand(client);
 }
 
 stock bool Weapon_AddonsStartCustomSoundForLastMan(int client, int WhatSoundPlay)
@@ -55,6 +57,32 @@ stock bool Weapon_AddonsStartCustomSoundForLastMan(int client, int WhatSoundPlay
 			EmitCustomToClient(client, "#zombiesurvival/combinehell/escalationP2.mp3", client, SNDCHAN_STATIC, SNDLEVEL_NONE, _, 2.0);
 			SetMusicTimer(client, GetTime() + 195);
 		}*/
+		case 17:
+		{
+			switch(WhatCiv(client))
+			{
+				case Almina_Thorns, Almina_Thornless:{
+					EmitCustomToClient(client, "#zombiesurvival/iberia/wave_30.mp3",client, SNDCHAN_STATIC, SNDLEVEL_NONE, _, 1.5);
+					SetMusicTimer(client, GetTime() + 177);
+				}
+				case Thorns:{
+					EmitCustomToClient(client, "#zombiesurvival/expidonsa_waves/wave_45_music_1.mp3",client, SNDCHAN_STATIC, SNDLEVEL_NONE, _, 1.0);
+					SetMusicTimer(client, GetTime() + 279);
+				}
+				case Combine:{
+					EmitCustomToClient(client, "#zombiesurvival/xeno_raid/xeno_shared_bossmusic.mp3",client, SNDCHAN_STATIC, SNDLEVEL_NONE, _, 2.0);
+					SetMusicTimer(client, GetTime() + 170);
+				}
+				case Alternative:{
+					EmitCustomToClient(client, "#zombiesurvival/altwaves_and_blitzkrieg/music/wave60_2.mp3",client, SNDCHAN_STATIC, SNDLEVEL_NONE, _, 0.6);
+					SetMusicTimer(client, GetTime() + 320);
+				}
+				default:{
+					EmitCustomToClient(client, "#zombiesurvival/medieval_raid/kazimierz_boss.mp3",client, SNDCHAN_STATIC, SNDLEVEL_NONE, _, 1.8);
+					SetMusicTimer(client, GetTime() + 189);
+				}
+			}
+		}
 		default:CompleteFailure=true;
 	}
 	/*무엇도 해당 안되면 기본 라스맨 브금 재생*/
@@ -71,7 +99,28 @@ stock void Weapon_AddonsStopCustomSoundForLastMan(int client, int WhatSoundPlay)
 	switch(WhatSoundPlay)
 	{
 		//case 12:StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/combinehell/escalationP2.mp3", 2.0);
+		case 17:
+		{
+			StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/medieval_raid/kazimierz_boss.mp3", 2.0);
+			StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/altwaves_and_blitzkrieg/music/wave60_2.mp3", 2.0);
+			StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/iberia/wave_30.mp3", 2.0);
+			StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/xeno_raid/xeno_shared_bossmusic.mp3", 2.0);
+		}
 	}
+}
+
+stock bool Weapon_AddonsOverlayForLastMan(int client, int Overlay)
+{
+	if(client)
+	{
+		/*에러 제거용*/
+	}
+	/*lms발동때 화면에 흑백 적용 안할껀지 여부*/
+	switch(Overlay)
+	{
+		//case 12:StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/combinehell/escalationP2.mp3", 2.0);
+	}
+	return false;
 }
 
 void Weapon_AddonsCustom_WaveEnd()

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
@@ -212,8 +212,9 @@ static Action Timer_Barracks(Handle timer, DataPack pack)
 		}
 	}
 	
-	if(i_ClientHasCustomGearEquipped[client] != CUSTOMGEAR_NONE || !IsEntityAlive(client,_, true))
+	if(valid && (i_ClientHasCustomGearEquipped[client] != CUSTOMGEAR_NONE || !IsEntityAlive(client,_, true)))
 		return Plugin_Continue;
+		
 	if(!valid)
 	{
 		h_Barrack_Timer[clientindx] = null;

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
@@ -17,6 +17,8 @@ static float Barracks_NovaCDTime[MAXPLAYERS];				// Cd for the healing nova of t
 static float ReDash[MAXPLAYERS];							// For the 5s window of the Chain Hit
 static int WeaponSMGID[MAXPLAYERS];
 static int WeaponReconstructiveShotgunID[MAXPLAYERS];
+static float WeaponReconstructiveShotgunBuffTime[MAXPLAYERS];	
+static float GlobalReconstructiveShotgunSoundTime;	
 bool BR_Precached = false;
 
 /*
@@ -41,18 +43,21 @@ public void Barracks_OnMapStart()
 	//precache + zero stuff
 	PrecacheSound(WEAPON_SWITCH_SOUND);
 	PrecacheSound(CRIME_SOUND);
+	PrecacheSound("items/samurai/tf_conch.wav");
 	Zero(CivType);
 	Zero(WeaponPap);
 	Zero(ShotgunHeal);
 	Zero(ShotgunHeal_Targets);
 	Zero(BarracksBuffMode);
-	Zero(Barrack_HUDDelay);
+	ZeroFloat(Barrack_HUDDelay);
 	Zero(ResourceGen);
-	Zero(ReDash);
-	Zero(Barracks_NovaCDTime);
-	Zero(Barracks_PowerHitTime);
+	ZeroFloat(ReDash);
+	ZeroFloat(Barracks_NovaCDTime);
+	ZeroFloat(Barracks_PowerHitTime);
 	Zero(WeaponSMGID);
 	Zero(WeaponReconstructiveShotgunID);
+	ZeroFloat(WeaponReconstructiveShotgunBuffTime);
+	GlobalReconstructiveShotgunSoundTime=0.0;
 	
 	BR_Precached = false;
 }
@@ -61,6 +66,9 @@ void PrecacheBarracksMusic()
 	if(!BR_Precached)
 	{
 		PrecacheSoundCustom("#zombiesurvival/medieval_raid/kazimierz_boss.mp3", _, 1);
+		PrecacheSoundCustom("#zombiesurvival/altwaves_and_blitzkrieg/music/wave60_2.mp3", _, 1);
+		PrecacheSoundCustom("#zombiesurvival/iberia/wave_30.mp3", _, 1);
+		PrecacheSoundCustom("#zombiesurvival/xeno_raid/xeno_shared_bossmusic.mp3", _, 1);
 		BR_Precached = true;
 	} 
 }
@@ -94,14 +102,122 @@ static Action Timer_Barracks(Handle timer, DataPack pack)
 	int client = EntRefToEntIndex(pack.ReadCell());
 	
 	bool valid = IsValidClient(client);
+	if(valid)
+	{
+		int i_IsValidEntitys = EntRefToEntIndex(WeaponReconstructiveShotgunID[clientindx]);
+		if(!IsValidEntity(i_IsValidEntitys))
+			valid=false;
+		i_IsValidEntitys = EntRefToEntIndex(WeaponSMGID[clientindx]);
+		if(!IsValidEntity(i_IsValidEntitys))
+			valid=false;
+	}
+	
+	if(valid && WeaponReconstructiveShotgunBuffTime[clientindx] > GetGameTime())
+	{
+		//750Hu.
+		float position[3]; WorldSpaceCenter(clientindx, position);
+		position[2]+=3.0;
+		spawnRing_Vectors(position, 1430.0, 0.0, 0.0, 5.0, LASERBEAM, 200, 50, 50, 125, 1, 0.11, 5.0, 1.1, 5, _, client);
+		position[2]-=3.0;
+		for(int entitycount; entitycount<i_MaxcountNpcTotal; entitycount++)
+		{
+			int npc = EntRefToEntIndexFast(i_ObjectsNpcsTotal[entitycount]);
+			if(IsValidEntity(npc) && GetTeam(npc) == TFTeam_Red && (npc <= MaxClients || !b_NpcHasDied[npc]))
+			{
+				float position2[3], distance;
+				GetEntPropVector(npc, Prop_Send, "m_vecOrigin", position2);
+				distance = GetVectorDistance(position, position2, true);
+				if(distance<511225.0)
+				{
+					switch(WhatCiv(clientindx))
+					{
+						case Almina_Thorns, Almina_Thornless:{
+							ApplyStatusEffect(clientindx, npc, "Very Defensive Backup", 1.0);
+						}
+						case Thorns:{
+							ApplyStatusEffect(clientindx, npc, "Expidonsan War Cry", 1.0);
+						}
+						case Combine:{
+							ApplyStatusEffect(clientindx, npc, "Ancient Melodies", 1.0);
+							ApplyStatusEffect(clientindx, npc, "Healing Adaptiveness All", 1.0);
+						}
+						case Alternative:{
+							ApplyStatusEffect(clientindx, npc, "Weapon Clocking", 1.0);
+							ApplyStatusEffect(clientindx, npc, "Weapon Overclock", 1.0);
+						}
+						default:{
+							ApplyStatusEffect(clientindx, npc, "Godly Motivation", 1.0);
+						}
+					}
+				}
+			}
+		}
+		for(int target=1; target<=MaxClients; target++)
+		{
+			if(IsValidClient(target) && IsPlayerAlive(target) && target!=clientindx && TeutonType[target] != TEUTON_WAITING)
+			{
+				float position2[3], distance;
+				WorldSpaceCenter(target, position2);
+				distance = GetVectorDistance(position, position2, true);
+				if(distance<511225.0)
+				{
+					if(TeutonType[target] != TEUTON_NONE)
+					{
+						TF2_RemoveCondition(target, TFCond_SpeedBuffAlly);
+						TF2_AddCondition(target, TFCond_SpeedBuffAlly, 1.0);
+					}
+					
+					switch(WhatCiv(clientindx))
+					{
+						case Almina_Thorns, Almina_Thornless:{
+							ApplyStatusEffect(clientindx, target, "Very Defensive Backup", 1.0);
+						}
+						case Thorns:{
+							ApplyStatusEffect(clientindx, target, "Expidonsan War Cry", 1.0);
+						}
+						case Combine:{
+							ApplyStatusEffect(clientindx, target, "Weapon Clocking", 1.0);
+							ApplyStatusEffect(clientindx, target, "Weapon Overclock", 1.0);
+						}
+						case Alternative:{
+							ApplyStatusEffect(clientindx, target, "War Cry", 1.0);
+							ApplyStatusEffect(clientindx, target, "Defensive Backup", 1.0);
+						}
+						default:{
+							ApplyStatusEffect(clientindx, target, "Godly Motivation", 1.0);
+						}
+					}
+				}
+			}
+		}
+		switch(WhatCiv(clientindx))
+		{
+			case Almina_Thorns, Almina_Thornless:{
+				ApplyStatusEffect(clientindx, clientindx, "Very Defensive Backup", 1.0);
+			}
+			case Thorns:{
+				ApplyStatusEffect(clientindx, clientindx, "Expidonsan War Cry", 1.0);
+			}
+			case Combine:{
+				ApplyStatusEffect(clientindx, clientindx, "Ancient Melodies", 1.0);
+				ApplyStatusEffect(clientindx, clientindx, "Healing Adaptiveness All", 1.0);
+			}
+			case Alternative:{
+				ApplyStatusEffect(clientindx, clientindx, "Weapon Clocking", 1.0);
+				ApplyStatusEffect(clientindx, clientindx, "Weapon Overclock", 1.0);
+			}
+			default:{
+				ApplyStatusEffect(clientindx, clientindx, "Godly Motivation", 1.0);
+			}
+		}
+	}
+	
+	if(i_ClientHasCustomGearEquipped[client] != CUSTOMGEAR_NONE || !IsEntityAlive(client,_, true))
+		return Plugin_Continue;
 	if(!valid)
 	{
 		h_Barrack_Timer[clientindx] = null;
 		return Plugin_Stop;
-	}
-	if(i_ClientHasCustomGearEquipped[client] != CUSTOMGEAR_NONE || !IsEntityAlive(client,_, true))
-	{
-		return Plugin_Continue;
 	}
 	
 	Barracks_HUD(client);
@@ -157,12 +273,87 @@ public void Weapon_Marker_M2(int client, int weapon, bool crit, int slot)
 }
 public void Weapon_Hunter_M2(int client, int weapon, bool crit, int slot)
 {
-	EmitSoundToClient(client, WEAPON_SWITCH_SOUND, client, SNDCHAN_AUTO, BOSS_ZOMBIE_SOUNDLEVEL, _, BOSS_ZOMBIE_VOLUME);
-	FakeClientCommandEx(client, "use tf_weapon_smg");
+//	EmitSoundToClient(client, WEAPON_SWITCH_SOUND, client, SNDCHAN_AUTO, BOSS_ZOMBIE_SOUNDLEVEL, _, BOSS_ZOMBIE_VOLUME);
+//	FakeClientCommandEx(client, "use tf_weapon_smg");
+
+	if(!IsValidClient(client) || !IsPlayerAlive(client))
+		return;
+	float Ability_CD = Ability_Check_Cooldown(client, slot);
+
+	if(Ability_CD <= 0.0 || CvarInfiniteCash.BoolValue)
+		Ability_CD = 0.0;
+	if(Ability_CD > 0.0)
+	{
+		ClientCommand(client, "playgamesound items/medshotno1.wav");
+		SetDefaultHudPosition(client);
+		SetGlobalTransTarget(client);
+		ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Ability has cooldown", Ability_CD);
+		return;
+	}
+	if(WeaponReconstructiveShotgunBuffTime[client] > GetGameTime())
+	{
+		ClientCommand(client, "playgamesound items/medshotno1.wav");
+		SetDefaultHudPosition(client);
+		SetGlobalTransTarget(client);
+		ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Already Used");
+		return;
+	}
+	Rogue_OnAbilityUse(client, weapon);
+	Ability_Apply_Cooldown(client, slot, 90.0);
+	if(b_AlaxiosBuffItem[client])
+	{
+		int r = 200;
+		int g = 200;
+		int b = 255;
+		int a = 200;
+		EmitSoundToAll("mvm/mvm_tank_horn.wav", client, SNDCHAN_STATIC, 80, _, 0.45);
+		
+		spawnRing(client, 50.0 * 2.0, 0.0, 0.0, 5.0, "materials/sprites/laserbeam.vmt", r, g, b, a, 1, 0.5, 6.0, 6.1, 1);
+		spawnRing(client, 50.0 * 2.0, 0.0, 0.0, 25.0, "materials/sprites/laserbeam.vmt", r, g, b, a, 1, 0.4, 6.0, 6.1, 1);
+		spawnRing(client, 50.0 * 2.0, 0.0, 0.0, 45.0, "materials/sprites/laserbeam.vmt", r, g, b, a, 1, 0.3, 6.0, 6.1, 1);
+		spawnRing(client, 50.0 * 2.0, 0.0, 0.0, 65.0, "materials/sprites/laserbeam.vmt", r, g, b, a, 1, 0.2, 6.0, 6.1, 1);
+		spawnRing(client, 50.0 * 2.0, 0.0, 0.0, 85.0, "materials/sprites/laserbeam.vmt", r, g, b, a, 1, 0.1, 6.0, 6.1, 1);
+	}
+	
+	int AllyCount;
+	float position[3]; WorldSpaceCenter(client, position);
+	for(int entitycount; entitycount<i_MaxcountNpcTotal; entitycount++)
+	{
+		int npc = EntRefToEntIndexFast(i_ObjectsNpcsTotal[entitycount]);
+		if(IsValidEntity(npc) && GetTeam(npc) == TFTeam_Red && (npc <= MaxClients || !b_NpcHasDied[npc]))
+		{
+			float position2[3], distance;
+			GetEntPropVector(npc, Prop_Send, "m_vecOrigin", position2);
+			distance = GetVectorDistance(position, position2, true);
+			if(distance<511225.0)
+				AllyCount++;
+		}
+	}
+	for(int target=1; target<=MaxClients; target++)
+	{
+		if(IsValidClient(target) && IsPlayerAlive(target) && TeutonType[target] != TEUTON_WAITING)
+		{
+			float position2[3], distance;
+			WorldSpaceCenter(target, position2);
+			distance = GetVectorDistance(position, position2, true);
+			if(distance<511225.0)
+				AllyCount++;
+		}
+	}
+	//너무 씨그러운www
+	if(GlobalReconstructiveShotgunSoundTime < GetGameTime() && AllyCount > 2)
+	{
+		EmitSoundToAll("items/samurai/tf_conch.wav", client, SNDCHAN_STATIC, BOSS_ZOMBIE_SOUNDLEVEL , _, 0.5, GetRandomInt(80,110));
+		GlobalReconstructiveShotgunSoundTime = GetGameTime() + 15.0;
+	}
+	TF2_RemoveCondition(client, TFCond_SpeedBuffAlly);
+	TF2_AddCondition(client, TFCond_SpeedBuffAlly, 3.0);
+	WeaponReconstructiveShotgunBuffTime[client] = GetGameTime() + 8.0 + (float(WeaponPap[client]) * 2.0);
 }
 public void Enable_CastleSiege(int client, int weapon)
 {
 	WeaponSMGID[client] = EntIndexToEntRef(weapon);
+	Enable_Barracks(client, weapon);
 }
 public void Enable_Barracks_Hunter(int client, int weapon)
 {
@@ -174,17 +365,32 @@ bool Inv_ReconstructiveShotgun_Enable(int client)
 	return IsValidEntity(IsValidShotgun);
 }
 
-public void Weapon_CastleSiege_M2(int client, int weapon, bool crit, int slot)
+public void Barracks_OnLastManStand(int client)
 {
-	EmitSoundToClient(client, WEAPON_SWITCH_SOUND, client, SNDCHAN_AUTO, BOSS_ZOMBIE_SOUNDLEVEL, _, BOSS_ZOMBIE_VOLUME);
-	FakeClientCommandEx(client, "use tf_weapon_revolver");
+	int IsValidWeapon = EntRefToEntIndex(WeaponSMGID[client]);
+	if(IsValidEntity(IsValidWeapon))
+		Ability_Apply_Cooldown(client, 2, 0.0, IsValidWeapon);
+	IsValidWeapon = EntRefToEntIndex(WeaponReconstructiveShotgunID[client]);
+	if(IsValidEntity(IsValidWeapon))
+		Ability_Apply_Cooldown(client, 2, 0.0, IsValidWeapon);
+		
+	Barracks_PowerHitTime[client] -= 50.0;
+	Barracks_NovaCDTime[client] -= 10.0;
 }
+
+//public void Weapon_CastleSiege_M2(int client, int weapon, bool crit, int slot)
+//{
+//	EmitSoundToClient(client, WEAPON_SWITCH_SOUND, client, SNDCHAN_AUTO, BOSS_ZOMBIE_SOUNDLEVEL, _, BOSS_ZOMBIE_VOLUME);
+//	FakeClientCommandEx(client, "use tf_weapon_revolver");
+//}
 public void Barracks_OnTakeDamage_CastleSiege(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int zr_custom_damage)
 {
 	if(CheckInHud())
 	return;
 	if(HasSpecificBuff(victim, "Marked"))
 		damage*=1.0+(float(WeaponPap[attacker]) * 0.2);
+	ApplyStatusEffect(attacker, victim, "Marked", 4.0 + (WeaponPap[attacker] * 2));
+	SummonerRenerateResources(attacker, 0.1, 0.0, true);
 }
 public void Barracks_CastleSiegeMode(int client, int weapon, bool crit, int slot)
 {
@@ -218,11 +424,11 @@ public void Barracks_OnTakeDamage(int victim, int &attacker, int &inflictor, flo
 		int IsValidSMG = EntRefToEntIndex(WeaponSMGID[attacker]);
 		if(IsValidEntity(IsValidSMG))
 		{
-			float Ability_CD = Ability_Check_Cooldown(attacker, 3, IsValidSMG);
+			float Ability_CD = Ability_Check_Cooldown(attacker, 2, IsValidSMG);
 			Ability_CD-=2.0;
 			if(Ability_CD <= 0.0 || CvarInfiniteCash.BoolValue)
 				Ability_CD = 0.0;
-			Ability_Apply_Cooldown(attacker, 3, Ability_CD, IsValidSMG, true);
+			Ability_Apply_Cooldown(attacker, 2, Ability_CD, IsValidSMG, true);
 		}
 	}
 	
@@ -236,15 +442,16 @@ public void Barracks_OnTakeDamage_Hunter(int victim, int &attacker, int &inflict
 	
 	if(HasSpecificBuff(victim, "Marked"))
 	{
+		SummonerRenerateResources(attacker, 5.0 + (WeaponPap[attacker] * 3), 0.0, true);
 		damage *= (1.2 + ((WeaponPap[attacker] * 0.1)));
 		int IsValidSMG = EntRefToEntIndex(WeaponSMGID[attacker]);
 		if(IsValidEntity(IsValidSMG))
 		{
-			float Ability_CD = Ability_Check_Cooldown(attacker, 3, IsValidSMG);
-			Ability_CD-=1.0;
+			float Ability_CD = Ability_Check_Cooldown(attacker, 2, IsValidSMG);
+			Ability_CD-=3.0;
 			if(Ability_CD <= 0.0 || CvarInfiniteCash.BoolValue)
 				Ability_CD = 0.0;
-			Ability_Apply_Cooldown(attacker, 3, Ability_CD, IsValidSMG, true);
+			Ability_Apply_Cooldown(attacker, 2, Ability_CD, IsValidSMG, true);
 		}
 	}
 	if(Ability_Check_Cooldown(attacker, 2) < 0.0)
@@ -670,6 +877,26 @@ static void Barracks_HUD(int client)
 	else
 	{
 		Format(BarracksHud, sizeof(BarracksHud), "%s\nHealing Nova: [%.1f]", BarracksHud, NovaCD);
+	}
+	if(WeaponPap[client] >= 3)
+	{
+		float BuffTime = WeaponReconstructiveShotgunBuffTime[client] - GetGameTime();
+		if(BuffTime > 0.0)
+			Format(BarracksHud, sizeof(BarracksHud), "%s\nBattle-Banner ACTIVE!: [%.1f]", BarracksHud, BuffTime);
+		else
+		{
+			int IsValidShotgun = EntRefToEntIndex(WeaponReconstructiveShotgunID[client]);
+			if(IsValidEntity(IsValidShotgun))
+			{
+				BuffTime = Ability_Check_Cooldown(client, 2, IsValidShotgun);
+				if(BuffTime <= 0.0)
+					BuffTime = 0.0;
+				if(BuffTime > 0.0)
+					Format(BarracksHud, sizeof(BarracksHud), "%s\nBattle-Banner: [%.1f]", BarracksHud, BuffTime);
+				else
+					Format(BarracksHud, sizeof(BarracksHud), "%s\nBattle-Banner: Ready!", BarracksHud);
+			}
+		}
 	}
 
 	// Power-Strike + Chain-Hit, if you're wondering why it's called ReDash btw it's cause i thought about making it a dash, decided against it

--- a/addons/sourcemod/scripting/zombie_riot/music.sp
+++ b/addons/sourcemod/scripting/zombie_riot/music.sp
@@ -580,13 +580,18 @@ void Music_EndLastmann(bool Reinforce=false)
 						StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/heatbroken_lastman.mp3", 2.0);
 					case 16:
 						StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/red_mist_lastman.mp3", 2.0);
-					case 17:
-						StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/medieval_raid/kazimierz_boss.mp3", 2.0);
+				//	case 17:
+				//		StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/medieval_raid/kazimierz_boss.mp3", 2.0);
 					case 18:
 						StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/gunsaw_lastman.mp3", 2.0);
 					case 19:
 						StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/prescript_lastman.mp3", 2.0);
 
+
+
+
+					default:
+						Weapon_AddonsStopCustomSoundForLastMan(client, Yakuza_Lastman());
 				}
 				SetMusicTimer(client, 0);
 				MusicLastmann.StopMusic(client);
@@ -1081,11 +1086,11 @@ void Music_Update(int client)
 						SetMusicTimer(client, GetTime() + 91);
 					}
 				}
-				case 17:
-				{
-					EmitCustomToClient(client, "#zombiesurvival/medieval_raid/kazimierz_boss.mp3",client, SNDCHAN_STATIC, SNDLEVEL_NONE, _, 1.8);
-					SetMusicTimer(client, GetTime() + 189);
-				}
+			//	case 17:
+			//	{
+			//		EmitCustomToClient(client, "#zombiesurvival/medieval_raid/kazimierz_boss.mp3",client, SNDCHAN_STATIC, SNDLEVEL_NONE, _, 1.8);
+			//		SetMusicTimer(client, GetTime() + 189);
+			//	}
 				case 18:
 				{
 					EmitCustomToClient(client, "#zombiesurvival/gunsaw_lastman.mp3",client, SNDCHAN_STATIC, SNDLEVEL_NONE, _, 1.3);

--- a/addons/sourcemod/scripting/zombie_riot/object/obj_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/object/obj_barracks.sp
@@ -1069,11 +1069,13 @@ void Barracks_BuildingThink(int entity)
 					{
 						TrainingIndex[client] = TrainingQueue[client];
 						TrainingStartedIn[client] = GetGameTime();
-						float trainingTime = float(GetSData(CivType[client], TrainingQueue[client], TrainTime));
+						float trainingTime = float(LastMann ? (GetSData(CivType[client], TrainingQueue[client], TrainTime) / 3) : GetSData(CivType[client], TrainingQueue[client], TrainTime));
 						if(i_NormalBarracks_HexBarracksUpgrades[client] & ZR_BARRACKS_UPGRADES_CONSCRIPTION)
 						{
 							trainingTime *= 0.75;
 						}
+						if(HasSpecificBuff(client, "Barracks Prepare Siege"))
+							trainingTime *= 0.55;
 						if(CvarInfiniteCash.BoolValue)
 						{
 							trainingTime = 0.0;

--- a/addons/sourcemod/scripting/zombie_riot/zr_core.sp
+++ b/addons/sourcemod/scripting/zombie_riot/zr_core.sp
@@ -2623,6 +2623,7 @@ void TriggerLastmanLogic(int killed, int Hurtviasdkhook)
 					KitSurvivalist_LastmanBuff(client);
 				}
 				
+				Weapon_AddonsCustomLastMan(client);
 				for(int i=1; i<=MaxClients; i++)
 				{
 					if(IsClientInGame(i) && !IsFakeClient(i))


### PR DESCRIPTION
지휘관 킷:
\* 플레이어가 나가거나 장비 해제, 판매를 해도 초기화되지 않던 문제 수정
\- 마커(리볼버) 삭제
\= 공성전(SMG) R키를 M2로 변경
\+ 리볼버가 삭제됨에 따라 SMG에 표식 적용 능력 부여.
\+ 재구성 샷건 M2를 전투 깃발 발동으로 변경
\+ 리볼버가 삭제됨에 따라 재구성 샷건에 표적 대상 적중 시 자원 회복 추가.
\+ 전투 깃발: 자신이 설정한 배럭 유닛에 따라 다른 버프를 주변아군과 자신에게 적용함, 자신에게 이속 증진 3초 부여
├ 기본: 알락 함성 버프
├ 블츠: 과부하 우버 버프
├ 엑스피돈사: 강화 피해량 버프
└ 알미나: 강화 방어 버프
\+ 라스트맨 버프 적용(능력쿨 초기화 및 사용된 능력쿨 감소)
\+ 라스트맨 사운드가 배럭 유닛 설정에 따라 변경됨.
\+ 라스트맨 흑백 오버레이 삭제